### PR TITLE
checksums for config and secrets

### DIFF
--- a/honeycomb/Chart.yaml
+++ b/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 0.10.0
+version: 0.10.1
 appVersion: 2.0.0
 keywords:
   - observability

--- a/honeycomb/Chart.yaml
+++ b/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 0.10.1
+version: 0.11.0
 appVersion: 2.0.0
 keywords:
   - observability

--- a/honeycomb/README.md
+++ b/honeycomb/README.md
@@ -52,8 +52,9 @@ See [docs](https://github.com/honeycombio/honeycomb-kubernetes-agent/blob/master
 The [values.yaml](./values.yaml) file contains information about all configuration
 options for this chart.
 
-The only **required** option is `honeycomb.apiKey`. You can obtain your API Key by going to your Account profile 
-page inside of your Honeycomb instance.
+The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource with your API Key specified in the `api-key` field. 
+
+You can obtain your API Key by going to your Account profile page inside of your Honeycomb instance.
 
 ## Parameters
 
@@ -63,6 +64,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | --- | --- | --- |
 | `honeycomb.apiKey` | Honeycomb API Key | `YOUR_API_KEY` |
 | `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
+| `honeycomb.existingSecret` | Name of an existing secret resource to use containing your API Key in the `api-key` field | `nil` |
 | `agent.watchers` | An array of `watchers` configuration snippets for the agent ([docs](https://github.com/honeycombio/honeycomb-kubernetes-agent/blob/master/docs/configuration-reference.md)) | kube-controller-manager, kube-scheduler |
 | `agent.verbosity` | Agent log level | `info` |
 | `agent.splitLogging` | Send all log levels to stdout instead of stderr | `false` |

--- a/honeycomb/templates/NOTES.txt
+++ b/honeycomb/templates/NOTES.txt
@@ -1,9 +1,10 @@
 {{- $validApiKey := and (.Values.honeycomb.apiKey) (ne .Values.honeycomb.apiKey "YOUR_API_KEY") -}}
 
-{{- if not $validApiKey }}
+{{- if and (not $validApiKey) (not .Values.honeycomb.existingSecret) }}
 ##### ERROR:
-You must set the value for 'honeycomb.apiKey' to your API Key that you can find your API key in your Honeycomb
-account profile: https://ui.honeycomb.io/account
+You must either set the value for 'honeycomb.apiKey' to your API Key that you can find in your Honeycomb account
+profile: https://ui.honeycomb.io/account or set the value for 'honeycomb.existingSecret' with the name of an existing
+secret resource name which contains your API Key
 #####
 {{- end }}
 

--- a/honeycomb/templates/agent-daemonset.yaml
+++ b/honeycomb/templates/agent-daemonset.yaml
@@ -14,10 +14,12 @@ spec:
       {{- include "honeycomb.agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/agent-config.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}  
+        {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "honeycomb.agent.selectorLabels" . | nindent 8 }}
     spec:

--- a/honeycomb/templates/agent-daemonset.yaml
+++ b/honeycomb/templates/agent-daemonset.yaml
@@ -16,7 +16,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/agent-config.yaml") . | sha256sum }}
+        {{- if not .Values.honeycomb.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}  
+        {{- end }}
         {{- with .Values.podAnnotations }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -40,7 +42,11 @@ spec:
             - name: HONEYCOMB_WRITEKEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.honeycomb.existingSecret }}
+                  name: {{ .Values.honeycomb.existingSecret }}
+                  {{- else }}
                   name: {{ include "honeycomb.fullname" . }}
+                  {{- end }}
                   key: api-key
             - name: NODE_NAME
               valueFrom:

--- a/honeycomb/templates/events-deployment.yaml
+++ b/honeycomb/templates/events-deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "honeycomb.events.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.events.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}        
+        {{- with .Values.events.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "honeycomb.events.selectorLabels" . | nindent 8 }}
     spec:

--- a/honeycomb/templates/events-deployment.yaml
+++ b/honeycomb/templates/events-deployment.yaml
@@ -13,7 +13,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if not .Values.honeycomb.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}        
+        {{- end }}
         {{- with .Values.events.podAnnotations }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,7 +44,11 @@ spec:
             - name: HONEYCOMB_WRITEKEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.honeycomb.existingSecret }}
+                  name: {{ .Values.honeycomb.existingSecret }}
+                  {{- else }}
                   name: {{ include "honeycomb.fullname" . }}
+                  {{- end }}
                   key: api-key
           resources:
             {{- toYaml .Values.events.resources | nindent 12 }}

--- a/honeycomb/templates/metrics-deployment.yaml
+++ b/honeycomb/templates/metrics-deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "honeycomb.metrics.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.metrics.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}        
+        {{- with .Values.events.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "honeycomb.metrics.selectorLabels" . | nindent 8 }}
     spec:

--- a/honeycomb/templates/metrics-deployment.yaml
+++ b/honeycomb/templates/metrics-deployment.yaml
@@ -13,7 +13,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if not .Values.honeycomb.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}        
+        {{- end }}
         {{- with .Values.events.podAnnotations }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -42,7 +44,11 @@ spec:
             - name: HONEYCOMB_WRITEKEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.honeycomb.existingSecret }}
+                  name: {{ .Values.honeycomb.existingSecret }}
+                  {{- else }}
                   name: {{ include "honeycomb.fullname" . }}
+                  {{- end }}
                   key: api-key
           resources:
             {{- toYaml .Values.metrics.resources | nindent 12 }}

--- a/honeycomb/templates/secret.yaml
+++ b/honeycomb/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.honeycomb.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   api-key: {{ .Values.honeycomb.apiKey | b64enc | quote }}
+{{- end }}

--- a/honeycomb/values.yaml
+++ b/honeycomb/values.yaml
@@ -4,6 +4,8 @@ honeycomb:
   apiKey: YOUR_API_KEY
   # Specify host URL to send all events to
   apiHost: https://api.honeycomb.io/
+  # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
+  existingSecret: ""
 
 agent:
   # Honeycomb agent watchers configuration

--- a/opentelemetry-collector/Chart.yaml
+++ b/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.4.0
 keywords:
   - observability

--- a/opentelemetry-collector/Chart.yaml
+++ b/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: 0.4.0
 keywords:
   - observability

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -65,8 +65,9 @@ See [design docs](https://github.com/open-telemetry/opentelemetry-collector/blob
 The [values.yaml](./values.yaml) file contains information about all configuration
 options for this chart.
 
-The only **required** option is `honeycomb.apiKey`. You can obtain your API Key by going to your Account profile 
-page inside of your Honeycomb instance.
+The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource with your API Key specified in the `api-key` field. 
+
+You can obtain your API Key by going to your Account profile page inside of your Honeycomb instance.
 
 ## Parameters
 
@@ -77,6 +78,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `honeycomb.apiKey` | Honeycomb API Key | `YOUR_API_KEY` |
 | `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
 | `honeycomb.dataset` | Name of dataset to send data into | `opentelemetry-collector` |
+| `honeycomb.existingSecret` | Name of an existing secret resource to use containing your API Key in the `api-key` field | `nil` |
 | `config` | OpenTelemetry Collector Configuration ([design docs](https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md)) | receivers: [otlp, jaeger, zipkin] / processors: [memory_limiter, batch, queued_retry] / exporters: [honeycomb] |
 | `nameOverride` | String to partially override opentelemetry-collector.fullname template with a string (will append the release name) | `nil` |
 | `fullnameOverride` | String to fully override opentelemetry-collector.fullname template with a string | `nil` |

--- a/opentelemetry-collector/templates/NOTES.txt
+++ b/opentelemetry-collector/templates/NOTES.txt
@@ -1,9 +1,10 @@
 {{- $validApiKey := and (.Values.honeycomb.apiKey) (ne .Values.honeycomb.apiKey "YOUR_API_KEY") -}}
 
-{{- if not $validApiKey }}
+{{- if and (not $validApiKey) (not .Values.honeycomb.existingSecret) }}
 ##### ERROR:
-You must set the value for 'honeycomb.apiKey' to your API Key that you can find your API key in your Honeycomb
-account profile: https://ui.honeycomb.io/account
+You must either set the value for 'honeycomb.apiKey' to your API Key that you can find in your Honeycomb account
+profile: https://ui.honeycomb.io/account or set the value for 'honeycomb.existingSecret' with the name of an existing
+secret resource name which contains your API Key
 #####
 {{- end }}
 

--- a/opentelemetry-collector/templates/deployment.yaml
+++ b/opentelemetry-collector/templates/deployment.yaml
@@ -13,10 +13,12 @@ spec:
       {{- include "opentelemetry-collector.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-    {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
     spec:

--- a/opentelemetry-collector/templates/deployment.yaml
+++ b/opentelemetry-collector/templates/deployment.yaml
@@ -15,7 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if not .Values.honeycomb.existingSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
             {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -48,7 +50,11 @@ spec:
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.honeycomb.existingSecret }}
+                  name: {{ .Values.honeycomb.existingSecret }}
+                  {{- else }}
                   name: honeycomb-{{ include "opentelemetry-collector.fullname" . }}
+                  {{- end }}
                   key: api-key
           ports:
             - name: otlp 

--- a/opentelemetry-collector/templates/secret.yaml
+++ b/opentelemetry-collector/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.honeycomb.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   api-key: {{ .Values.honeycomb.apiKey | b64enc | quote }}
+{{- end }}

--- a/opentelemetry-collector/values.yaml
+++ b/opentelemetry-collector/values.yaml
@@ -9,6 +9,8 @@ honeycomb:
   apiHost: https://api.honeycomb.io/
   # Specify the name of the dataset to send data to
   dataset: opentelemetry-collector
+  # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
+  existingSecret: ""
 
 
 config:


### PR DESCRIPTION
Added checksum annotation(s) to all deploy pods. Updating a config setting or API key will now force a restart on all affected pods with a `helm upgrade ...` command.