### PR TITLE
Use OpenTelemetry-Collector 0.6.0

### DIFF
--- a/opentelemetry-collector/Chart.yaml
+++ b/opentelemetry-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.1.0
-appVersion: 0.4.0
+version: 0.2.0
+appVersion: 0.6.0
 keywords:
   - observability
   - tracing

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -99,3 +99,9 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `nodeSelector` | Node labels for pod assignment | `{}` | 
 | `tolerations` | Tolerations for pod assignment | `[]`| 
 | `affinity` | Map of node/pod affinities | `{}` |
+
+
+## Upgrading
+
+### Upgrading from 0.1.1 or earlier.
+A breaking change in the OTLP receiver configuration was introduced. This change is part of the default configuration. If you changed the default OTLP receiver configuration, you will need to ensure your changes are compatible with the updated configuration layout for OTLP.

--- a/opentelemetry-collector/values.yaml
+++ b/opentelemetry-collector/values.yaml
@@ -14,15 +14,14 @@ honeycomb:
 config:
   receivers:
     otlp:
-      endpoint: 0.0.0.0:55680
+      protocols:
+        grpc:
+        http:
     jaeger:
       protocols:
         grpc:
-          endpoint: 0.0.0.0:14250
         thrift_http:
-          endpoint: 0.0.0.0:14268
     zipkin:
-      endpoint: 0.0.0.0:9411
 
   processors:
     batch:


### PR DESCRIPTION
Moving to 0.6.0 of the OpenTelemetry-Collector.

OpenTelemetry introduced a breaking change to the OTLP receiver configuration. The risk for those affected is very low since the change is contained within the default config of this chart.

Chart minor version is bumped because of the change.