### PR TITLE
Secure Tenancy chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ You can use Helm for installing [Honeycomb](https://honeycomb.io) packages in yo
 
 Packages:
 - [Honeycomb Kubernetes Agent](./honeycomb/)
+- [Honeycomb Secure Tenancy Proxy](./secure-tenancy)
+- [OpenTelemetry-Collector](./opentelemetry-collector)
 
 ## Installation
 

--- a/secure-tenancy/.helmignore
+++ b/secure-tenancy/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+
+resources/*

--- a/secure-tenancy/Chart.lock
+++ b/secure-tenancy/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: mariadb
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.6.1
+digest: sha256:f79ccdbf525702e7cfb5b923600e8636743acab8d1dbf25b66418a851530c191
+generated: "2020-07-22T15:27:06.444019-04:00"

--- a/secure-tenancy/Chart.yaml
+++ b/secure-tenancy/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: secure-tenancy
+description: Honeycomb Secure Tenancy
+version: 0.1.0
+appVersion: 1.2.1
+keywords:
+  - observability
+  - security
+dependencies:
+- name: mariadb
+  version: 7
+  repository: https://charts.bitnami.com/bitnami
+  condition: mysql.enabled
+  alias: mysql
+home: https://honeycomb.io
+icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
+maintainers:
+  - name: puckpuck
+    email: pierre@honeycomb.io

--- a/secure-tenancy/Chart.yaml
+++ b/secure-tenancy/Chart.yaml
@@ -17,3 +17,5 @@ icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
   - name: puckpuck
     email: pierre@honeycomb.io
+  - name: nathanleclaire
+    email: nathan@honeycomb.io

--- a/secure-tenancy/README.md
+++ b/secure-tenancy/README.md
@@ -12,7 +12,7 @@ This helm chart will install the [Honeycomb Secure Tenancy Proxy](https://docs.h
 Before installing this chart you will need to have Secure Tenancy enabled for your Honeycomb team. You will need to contact Honeycomb customer support or your account representative to have the functionality enabled.
 
 ### Building Image
-Honeycomb will provide you with a tarball for Secure Tenancy. You will need to build the image using the provided [Dockerfile](./resources/Dockerfile). Copy the Secure Tenancy tarbal into the same folder as the Dockerfile as `secure-tenancy.tbz` then run the followoing replacing YOUR_REPOSITORY accordingly:
+Honeycomb will provide you with a tarball for Secure Tenancy. You will need to build the image using the provided [Dockerfile](./resources/Dockerfile). Copy the Secure Tenancy tarball into the same folder as the Dockerfile as `secure-tenancy.tbz` then run the followoing replacing YOUR_REPOSITORY accordingly:
 
 ```bash
 docker build -t YOUR_REPOSITORY/honeycomb/secure-tenancy .

--- a/secure-tenancy/README.md
+++ b/secure-tenancy/README.md
@@ -1,0 +1,126 @@
+# Honeycomb Secure Tenancy Proxy
+
+[Honeycomb](https://honeycomb.io) is built for modern dev teams to see and understand how their production systems are 
+behaving. Our goal is to give engineers the observability they need to eliminate toil and delight their users.
+This helm chart will install the [Honeycomb Secure Tenancy Proxy](https://docs.honeycomb.io/authentication-and-security/secure-tenancy/).
+
+## Prerequisites
+- Helm 3.0+
+
+## Preparing to install chart
+### Enable Secure Tenancy in Honeycomb
+Before installing this chart you will need to have Secure Tenancy enabled for your Honeycomb team. You will need to contact Honeycomb customer support or your account representative to have the functionality enabled.
+
+### Building Image
+Honeycomb will provide you with a tarball for Secure Tenancy. You will need to build the image using the provided [Dockerfile](./resources/Dockerfile). Copy the Secure Tenancy tarbal into the same folder as the Dockerfile as `secure-tenancy.tbz` then run the followoing replacing YOUR_REPOSITORY accordingly:
+
+```bash
+docker build -t YOUR_REPOSITORY/honeycomb/secure-tenancy .
+docker push YOUR_REPOSITORY/honeycomb/secure-tenancy
+```
+
+## Installing the chart
+### Simple install (recommended for testing)
+This will install the Secure Tenancy proxy, and a MySQL database using the Bitnami MariaDB chart.
+A job to migrate and initialize the database will also be run as a post-install hook.
+Since the job requires the MySQL database to be up and running, the Helm install command below may not return for upto 
+3 minutes.
+```bash
+helm repo add honeycomb https://honeycombio.github.io/helm-charts
+helm install secure-tenancy honeycomb/secure-tenancy \
+    --set honeycomb.authToken=YOUR_SECURE_TENANCY_TOKEN \
+    --set image.repository=YOUR_REPOSITORY/honeycomb/secure-tenancy
+```
+
+### Advanced install (recommended for production)
+It's recommended to use a Helm values file to install this chart. The `honeycomb.authToken` and `image.repository` parameters are required. 
+When used in a production environment a MySQL database is typically provided. 
+You will need to set `mysql.enabled` to false, and `mysql.existingHost` to the host and port of the provided database.
+All parameters, including those used for database credentials are described in the [Parameters](#parameters) section.
+A typical installation values file may look like the following:
+```yaml
+honeycomb:
+  authToken: YOUR_SECURE_TENANCY_TOKEN
+
+image:
+  repository: YOUR_REPOSITORY/honeycomb/secure-tenancy
+
+metrics:
+  apiKey: YOUR_API_KEY
+  dataset: secure-tenancy-metrics
+
+mysql:
+  enabled: false
+  existingHost: mysql.mysql:3306
+  db:
+    # MySQL user
+    user: hny-secure-tenancy
+    # MySQL password
+    password: db_password
+    # MySQL database
+    name: hny-secure-tenancy
+```
+
+After the Helm values file is created, you can install the chart
+```bash
+helm repo add honeycomb https://honeycombio.github.io/helm-charts
+helm install secure-tenancy honeycomb/secure-tenancy --values my-values.yaml
+```
+
+## Parameters
+
+The following table lists the configurable parameters of the Honeycomb chart, and their default values.
+
+| Parameter | Description | Default |
+| --- | --- | --- |
+| `honeycomb.authToken` | Honeycomb Secure Tenancy authorization token | `YOUR_AUTH_TOKEN` |
+| `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
+| `honeycomb.uiBaseUrl` | URL used to access Honeycomb UI | `https://ui.honeycomb.io` |
+| `honeycomb.maxIdleConnsPerHost` | Maximum # of Idle connections to MySQL database | `100` |
+| `honeycomb.hsts.enabled` | Wether or not to enable HTTP Strict Transport Security | `false` |
+| `honeycomb.hsts.maxAge` | When HTST is enabled this is the max age in seconds | `31536000` |
+| `honeycomb.transformer` | The Transformer to use for Secure Tenancy. Must be `aes256siv` or `sha256hmac` | `aes256siv` |
+| `nameOverride` | String to partially override honeycomb.fullname template with a string (will append the release name) | `nil` |
+| `fullnameOverride` | String to fully override honeycomb.fullname template with a string | `nil` |
+| `imagePullSecrets` | Specify docker-registry secret names as an array | `[]` |
+| `image.repository` | Honeycomb Secure Tenancy proxy repository and image name | `nil` |
+| `image.tag` | Image tag to use (leave blank for latest) | `nil` |
+| `image.pullPolicy` | Honeycomb agent image pull policy | `IfNotPresent` |
+| `replicaCount` | Number of Secure Tenancy proxy server replicas to run | `2` |
+| `metrics.apiKey` | Honeycomb API Key for Team to receive metrics about Secure Tenancy proxy | `YOUR_API_KEY` |
+| `metrics.dataset` | Name of dataset to sent metrics to | `secure-tenancy` |
+| `metrics.apiHost` | API URL to sent metrics to | `https://api.honeycomb.io` |
+| `mysql.enabled` | When true the Bitnami MariaDB chart will be installed. | `true` |
+| `mysql.existingHost` | If `mysql.enabled` is false, this must be set to the name and port of an existing MySQL database | `nil` |
+| `mysql.tls` | Use TLS when communicating with MySQL | `false` |
+| `mysql.maxopenconns` | Maximum open connections to MySQL | `100` |
+| `mysql.db.user` | Name of MySQL user to connect as | `hny-secure-tenancy` |
+| `mysql.db.password` | Password for database user | `db_password` |
+| `mysql.db.name` | Name of MySQL database to connect | `hny-secure-tenancy` |
+| `mysql.rootUser.password` | When `mysql.enabled` is true this will be the root password used | `root_password` |
+| `mysql.replication.password` | When `mysql.enabled` is true this will be the replication password used | `replication_password` |
+| `service.type` | Kubernetes Service type | `ClusterIP` |
+| `service.port` | Service HTTP port | `80` |
+| `service.ip` | LoadBalancer service IP address | `nil` |
+| `service.annotations` | Service annotations | `{}` |
+| `ingress.enabled` | Enable ingress controller resource | `false` |
+| `ingress.annotations` | Ingress annotations | `{}` |
+| `ingress.hosts[0].name` | Hostname to your Secure Tenancy installation | `secure-tenancy.local` |
+| `ingress.hosts[0].paths` | Path within the url structure | `[]` |
+| `ingress.tls` | TLS hosts	| `[]` |
+| `autoscaling.enabled` | Enable autoscaling for Secure Tenancy deployment | `false` |
+| `autoscaling.minReplicas` | Minimum number of replicas to scale back (should be no less than 2) | `2` |
+| `autoscaling.maxReplicas` | Maximum number of replicas to scale out | `100` |
+| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80` |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage | `80` |
+| `podAnnotations` | Pod annotations | `{}` |
+| `resources` | CPU/Memory resource requests/limits | `{}` | 
+| `nodeSelector` | Node labels for pod assignment | `{}` | 
+| `tolerations` | Tolerations for pod assignment | `[]`| 
+| `affinity` | Map of node/pod affinities | `{}` |
+
+## Template Manifest
+It may be desired to have Helm render Kubernetes manifests but not have them installed.
+You can use the `helm template` command to accomplish this. 
+By default the output Kubernetes manifests will contain Helm specific annotations.
+You can remove these from the output templates by setting a special `omitHelm` parameter to false when generating the templates.

--- a/secure-tenancy/resources/Dockerfile
+++ b/secure-tenancy/resources/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stretch-slim
+
+RUN mkdir -p /srv/hny && \
+    apt-get update && \
+    apt-get install -y ca-certificates openssl bzip2
+WORKDIR /srv/hny
+
+# Need to build with tarball (provided by HNY team) adjacent in docker build directory
+COPY secure-tenancy.tbz secure-tenancy.tbz
+RUN tar --strip-components 1 -xjf secure-tenancy.tbz && \
+    rm secure-tenancy.tbz

--- a/secure-tenancy/templates/NOTES.txt
+++ b/secure-tenancy/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "secure-tenancy.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "secure-tenancy.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "secure-tenancy.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "secure-tenancy.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/secure-tenancy/templates/_helpers.tpl
+++ b/secure-tenancy/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "secure-tenancy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "secure-tenancy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "secure-tenancy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secure-tenancy.labels" -}}
+{{ include "secure-tenancy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if not .Values.omitHelm }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "secure-tenancy.chart" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "secure-tenancy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "secure-tenancy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "db.fullhost" -}}
+{{- if .Values.mysql.enabled }}
+{{- printf "%s-%s" .Release.Name "mysql" | trunc 63 | trimSuffix "-" -}}:{{ .Values.mysql.service.port }}
+{{- else }}
+{{- .Values.mysql.existingHost }}
+{{- end }}
+{{- end }}

--- a/secure-tenancy/templates/configmap.yaml
+++ b/secure-tenancy/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}
+  labels:
+  {{- include "secure-tenancy.labels" . | nindent 4 }}
+data:
+  hnyconfig.yaml: |
+    ui_base_url: {{ .Values.honeycomb.uiBaseUrl | quote }}
+    api_base_url: {{ .Values.honeycomb.apiHost | quote }}
+    libhoney_dataset: {{ .Values.metrics.dataset | quote }}
+    libhoney_api_url: {{ .Values.metrics.apiHost | quote }}
+    http_strict_transport_security_enabled: {{ .Values.honeycomb.hsts.enabled }}
+    http_strict_transport_security_max_age: {{ .Values.honeycomb.hsts.maxAge }}
+    max_idle_conns_per_host: {{ .Values.honeycomb.maxIdleConnsPerHost }}
+  mysqlconfig.yaml: |
+    host: "{{ include "db.fullhost" . }}"
+    database: {{ .Values.mysql.db.name | quote }}
+    tls: {{ .Values.mysql.tls }}
+    maxopenconns: {{ .Values.mysql.maxopenconns }}

--- a/secure-tenancy/templates/deployment.yaml
+++ b/secure-tenancy/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}
+  labels:
+    {{- include "secure-tenancy.labels" . | nindent 4 }}
+spec:
+{{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "secure-tenancy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "secure-tenancy.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/srv/hny/bin/honeycomb_secure_proxy"     
+            - "-hnyconfig=/config/hnyconfig.yaml"
+            - "-mysqlconfig=/config/mysqlconfig.yaml"
+            - "-transformer={{ .Values.honeycomb.transformer }}"
+          env:
+            - name: HONEYCOMB_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}
+                  key: auth-token
+            {{- if .Values.metrics.apiKey }}
+            - name: LIBHONEY_WRITE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}
+                  key: libhoney-api-key
+            {{- end }}
+            - name: HONEYCOMB_MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}
+                  key: mysql-user
+            - name: HONEYCOMB_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}
+                  key: mysql-password
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "secure-tenancy.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/secure-tenancy/templates/hpa.yaml
+++ b/secure-tenancy/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}
+  labels:
+    {{- include "secure-tenancy.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "secure-tenancy.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+{{- end }}

--- a/secure-tenancy/templates/ingress.yaml
+++ b/secure-tenancy/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "secure-tenancy.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "secure-tenancy.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/secure-tenancy/templates/migrate-job.yaml
+++ b/secure-tenancy/templates/migrate-job.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}-migrate
+  labels:
+    {{- include "secure-tenancy.labels" . | nindent 4 }}
+  annotations:
+    {{- if not .Values.omitHelm }}
+    {{- if .Values.mysql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+spec:
+  backoffLimit: 5
+  activeDeadlineSeconds: 200
+  template:
+    metadata:
+      labels:
+        {{- include "secure-tenancy.selectorLabels" . | nindent 8 }}
+    spec:  
+      restartPolicy: OnFailure   
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default "latest" }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/srv/hny/bin/migrate"]
+          args: 
+              - "-url"
+              - "mysql://$(HONEYCOMB_MYSQL_USER):$(HONEYCOMB_MYSQL_PASSWORD)@tcp({{ include "db.fullhost" . }})/{{ .Values.mysql.db.name }}?timeout=30s&tls={{ .Values.mysql.tls }}"
+              - "-path"
+              - "/srv/hny/migrate"
+              - "up"
+          env:
+            - name: HONEYCOMB_MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}-migrate
+                  key: mysql-user
+            - name: HONEYCOMB_MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "secure-tenancy.fullname" . }}-migrate
+                  key: mysql-password

--- a/secure-tenancy/templates/migrate-secret.yaml
+++ b/secure-tenancy/templates/migrate-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}-migrate
+  labels:
+  {{- include "secure-tenancy.labels" . | nindent 4 }}
+  annotations:
+    {{- if not .Values.omitHelm }}
+    {{- if .Values.mysql.enabled }}
+    "helm.sh/hook": post-install
+    {{- else }}
+    "helm.sh/hook": pre-install
+    {{- end }}
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+type: Opaque
+data:
+  mysql-user: {{ .Values.mysql.db.user | b64enc | quote }}
+  mysql-password: {{ .Values.mysql.db.password | b64enc | quote }}

--- a/secure-tenancy/templates/secret.yaml
+++ b/secure-tenancy/templates/secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}
+  labels:
+  {{- include "secure-tenancy.labels" . | nindent 4 }}
+type: Opaque
+data:
+  auth-token: {{ .Values.honeycomb.authToken | b64enc | quote }}
+  {{- if .Values.metrics.apiKey }}
+  libhoney-api-key: {{ .Values.metrics.apiKey | b64enc | quote }}
+  {{- end }}
+  mysql-user: {{ .Values.mysql.db.user | b64enc | quote }}
+  mysql-password: {{ .Values.mysql.db.password | b64enc | quote }}

--- a/secure-tenancy/templates/service.yaml
+++ b/secure-tenancy/templates/service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "secure-tenancy.fullname" . }}
+  labels:
+    {{- include "secure-tenancy.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}    
+spec:
+  type: {{ .Values.service.type }}
+  {{- if .Values.service.ip }}
+  loadBalancerIP: {{ .Values.service.ip }}
+  {{- end}}  
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "secure-tenancy.selectorLabels" . | nindent 4 }}

--- a/secure-tenancy/values.yaml
+++ b/secure-tenancy/values.yaml
@@ -1,0 +1,120 @@
+
+honeycomb:
+  # Specify Auth Token used for Secure Tenancy
+  authToken: YOUR_AUTH_TOKEN
+  # Specify host URL to send all events to
+  apiHost: https://api.honeycomb.io
+  
+  uiBaseUrl: https://ui.honeycomb.io
+  
+  maxIdleConnsPerHost: 100
+  hsts:
+    enabled: false
+    maxAge: 31536000
+
+  # Transformer to use.  Valid values are `aes256siv` or `sha256hmac`
+  transformer: aes256siv
+  
+
+image:
+  # this must be provided
+  repository: 
+  tag:
+  pullPolicy: IfNotPresent
+
+
+replicaCount: 2
+
+
+# Secure Tenancy self-metrics.
+metrics:
+  # leave API key blank to disable self-metrics
+  apiKey:
+  dataset: secure-tenancy
+  apiHost: https://api.honeycomb.io
+
+
+mysql:
+  # to install the mysql chart (mariadb from bitnami) set this to true
+  # if false, you must specify a value for existingHost
+  enabled: true
+  # if mysql.enabled is false this needs to be specified when the name of the host
+  # when specified mysql will not be installed and the specified host:port will be used instead
+  # this takes not effect if mysql.enabled is true
+  # existingHost: 
+
+  # Use TLS when communicating with MySQL
+  tls: false
+  # Max open connections
+  maxopenconns: 100
+
+  db:
+    # MySQL user
+    user: hny-secure-tenancy
+    # MySQL password
+    password: db_password
+    # MySQL database
+    name: hny-secure-tenancy
+  
+  # if mysql.enabled is true, ths is the root password used
+  rootUser:
+    password: root_password
+  # if mysql.enabled is true, this is the replication password, can be disabled with mysql.replication.enabled set to false
+  replication:
+    password: replication_password
+
+  # disable tests by default 
+  tests:
+    enabled: false
+
+       
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  annotations: {}
+  type: ClusterIP
+  port: 80
+  # If using a LoadBalancer service, you may also want to specify the IP to use
+  # ip: 
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: secure-tenancy.local
+      paths: []
+  tls: []
+  #  - secretName: secure-tenancy-tls
+  #    hosts:
+  #      - secure-tenancy.local
+
+autoscaling:
+  enabled: false
+  minReplicas: 2
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+podAnnotations: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Helm chart to install Secure Tenancy.  Requires user to build and supply an image on private repository for Secure Tenancy binary.  

- Easy to get going, by default it will setup and install a MySQL database to use
- Can also use an existing MySQL database instead
- Migrate script will run with `helm install` commands, as either a post-install (when install MySQL) or pre-install (when using an existing MySQL) hook.
- Includes support for Ingress
- Includes support for horizontal pod autoscaling
