### PR TITLE
Fix release script (for secure-tenancy)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -27,6 +27,9 @@ mkdir ${BUILD_DIR}
 
 # create new tgz
 echo "creating new ${CHART_NAME} helm package"
+if ! helm dependency build "./${CHART_NAME}" ; then
+    echo "Failure: could not build chart dependencies"
+fi
 if ! helm package -d ${BUILD_DIR} "./${CHART_NAME}" ; then
     echo "Failure: error creating helm package"
     exit 1

--- a/secure-tenancy/Chart.lock
+++ b/secure-tenancy/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 7.6.1
-digest: sha256:f79ccdbf525702e7cfb5b923600e8636743acab8d1dbf25b66418a851530c191
-generated: "2020-07-22T15:27:06.444019-04:00"
+digest: sha256:8eae6d7cb5b9ea45e39d81172b898a143940c42ca4ee945c80b9e72ccf8025a1
+generated: "2020-07-30T20:02:54.503797-04:00"

--- a/secure-tenancy/Chart.yaml
+++ b/secure-tenancy/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - security
 dependencies:
 - name: mariadb
-  version: 7
+  version: 7.6.1
   repository: https://charts.bitnami.com/bitnami
   condition: mysql.enabled
   alias: mysql


### PR DESCRIPTION
Adds dependency build to release script.

Also locked the mariadb dependency on secure-tenancy to version 7.6.1