### PR TITLE
Add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For anything not explicitly taken by someone else:
+* @puckpuck


### PR DESCRIPTION
Added CODEOWNERS file so team members are automatically set as reviewers. I've provisionally set @puckpuck as the only entry. Ideally it would be a team, but not sure if there is an appropriate one right now.

@paulosman @maplebed who do you think should be responsible for this?