### PR TITLE
Always create ConfigMap

### DIFF
--- a/honeycomb/templates/config.yaml
+++ b/honeycomb/templates/config.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.rbac.create  }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,4 +22,3 @@ data:
     metrics:
     {{- toYaml .Values.metrics | nindent 6 }}
 
-  {{- end }}


### PR DESCRIPTION
Currently the ConfigMap is only created when rbac.create=true, even though it's not an RBAC resource.

We've installed the chart with `rbac.create=false` to manage the RBAC resources out-of-band, but this caused the ConfigMap not to get installed. I can't think of a reason why the ConfigMap should be gated on `rbac.create`, or a reason to gate it on anything at all, but I'm happy to add a `configmap.create` or similar value if that would be useful.