### PR TITLE
Add in k8s tagger config

### DIFF
--- a/honeycomb/templates/rbac.yaml
+++ b/honeycomb/templates/rbac.yaml
@@ -11,6 +11,6 @@ roleRef:
   name: {{ include "honeycomb.agent.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "honeycomb.fullname" . }}
+    name: {{ include "honeycomb.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/opentelemetry-collector/README.md
+++ b/opentelemetry-collector/README.md
@@ -103,6 +103,11 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `nodeSelector` | Node labels for pod assignment | `{}` | 
 | `tolerations` | Tolerations for pod assignment | `[]`| 
 | `affinity` | Map of node/pod affinities | `{}` |
+| `serviceAccount.create` | Specify whether a ServiceAccount should be created | `true` | 
+| `serviceAccount.name` | The name of the ServiceAccount to create | Generated using the `honeycomb.fullname` template |
+| `serviceAccount.annotations` | Annotations to be applied to ServiceAccount | `{}` |
+| `k8sProcessor.rbac.create` | Specify whether the cluster-role and cluster-role-bindings should be created for the k8s_tagger processor | `false` |
+| `k8sProcessor.rbac.name` | Name of the cluster-role and cluster-role-bindings for the k8s_tagger processor  | Generated using the `opentelemetry-collector.fullname` template `{opentelemetry-collector.fullname}-k8sprocessor` |
 
 
 ## Upgrading

--- a/opentelemetry-collector/templates/_helpers.tpl
+++ b/opentelemetry-collector/templates/_helpers.tpl
@@ -50,3 +50,26 @@ Selector labels
 app.kubernetes.io/name: {{ include "opentelemetry-collector.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Service account name to use
+*/}}
+{{- define "opentelemetry-collector.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "opentelemetry-collector.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+K8s processor rbac/role name to use
+*/}}
+{{- define "opentelemetry-collector.k8sprocessor.RBACName" -}}
+{{- if .Values.k8sProcessor.rbac.create }}
+{{- $defaultname := printf "%s-%s" (include "opentelemetry-collector.fullname" .) "k8sprocessor" }}
+{{- default $defaultname .Values.k8sProcessor.rbac.name }}
+{{- else }}
+{{- default "default" .Values.k8sProcessor.rbac.name }}
+{{- end }}
+{{- end }}

--- a/opentelemetry-collector/templates/deployment.yaml
+++ b/opentelemetry-collector/templates/deployment.yaml
@@ -24,10 +24,12 @@ spec:
       labels:
         {{- include "opentelemetry-collector.selectorLabels" . | nindent 8 }}
     spec:
+
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      serviceAccountName: {{ include "opentelemetry-collector.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/opentelemetry-collector/templates/k8sProcessor-cluster-role.yaml
+++ b/opentelemetry-collector/templates/k8sProcessor-cluster-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.k8sProcessor.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "k8sProcessor.rbac.name" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - nodes/stats
+      - nodes/proxy
+    verbs:
+      - get
+      - list
+      - watch
+{{- end }}

--- a/opentelemetry-collector/templates/k8sProcessor-cluster-role.yaml
+++ b/opentelemetry-collector/templates/k8sProcessor-cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "k8sProcessor.rbac.name" . }}
+  name: {{ include "opentelemetry-collector.k8sprocessor.RBACName" . }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   annotations:

--- a/opentelemetry-collector/templates/k8sProcessor-rbac.yaml
+++ b/opentelemetry-collector/templates/k8sProcessor-rbac.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.k8sProcessor.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "k8sProcessor.rbac.name" . }}
+  labels:
+  {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "k8sProcessor.rbac.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "opentelemetry-collector.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/opentelemetry-collector/templates/k8sProcessor-rbac.yaml
+++ b/opentelemetry-collector/templates/k8sProcessor-rbac.yaml
@@ -2,15 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "k8sProcessor.rbac.name" . }}
+  name: {{ include "opentelemetry-collector.k8sprocessor.RBACName" . }}
   labels:
   {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "k8sProcessor.rbac.name" . }}
+  name: {{ include "opentelemetry-collector.k8sprocessor.RBACName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "opentelemetry-collector.fullname" . }}
+    name: {{ include "opentelemetry-collector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/opentelemetry-collector/templates/serviceaccount.yaml
+++ b/opentelemetry-collector/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "opentelemetry-collector.serviceAccountName" . }}
+  labels:
+    {{- include "opentelemetry-collector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/opentelemetry-collector/values.yaml
+++ b/opentelemetry-collector/values.yaml
@@ -107,3 +107,19 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+k8sProcessor:
+  rbac:
+    # Specifies whether roles based access control rules should be created.
+    create: false
+    name: ""
+
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}


### PR DESCRIPTION
Can easily create the roles and service accounts required to use the k8s_tagger.