### PR TITLE
Add NODE_IP to agent configuration

### DIFF
--- a/honeycomb/Chart.yaml
+++ b/honeycomb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.0.2
-appVersion: 2.1.2
+version: 1.0.3
+appVersion: 2.1.3
 keywords:
   - observability
   - tracing

--- a/honeycomb/templates/daemonset.yaml
+++ b/honeycomb/templates/daemonset.yaml
@@ -52,6 +52,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
Adding NODE_IP allows for seamless functionality in some managed clusters that don't have DNS entries for node names.

This depends on [Honeycomb Agent PR 145](https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/145) to be merged and released first.