### PR TITLE
Add sample configs for Refinery

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -1,4 +1,4 @@
-# Refinery: Sampling Proxy Service for Honeycomb
+# Honeycomb Refinery
 
 [Refinery](https://github.com/honeycombio/refinery) is a trace-aware sampling proxy server for Honeycomb.
 

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -34,7 +34,7 @@ The **Sample Rate** in Honeycomb is expressed as the denominator for 1 out of X 
 A sample rate of 20 means to keep 1 event from every 20, which is also equivalent to a 5% sampling you may see with other platforms.
 
 [The Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/) goes into more detail about how each sampling method works.
-These example configurations are provided to demonstrate how to define rules in YAML.
+These example configurations are provided to demonstrate how to define rules in YAML. See the complete definitions in the [sample-configs](./sample-configs) folder.
 
 ### Deterministic Sampler
 

--- a/charts/refinery/sample-configs/config_complete.yaml
+++ b/charts/refinery/sample-configs/config_complete.yaml
@@ -1,0 +1,256 @@
+#####################
+## Refinery Config ##
+#####################
+
+# ListenAddr is the IP and port on which to listen for incoming events. Incoming
+# traffic is expected to be HTTP, so if using SSL put something like nginx in
+# front to do the decryption.
+# Should be of the form 0.0.0.0:8080
+# Not eligible for live reload.
+ListenAddr: '0.0.0.0:8080'
+
+# GRPCListenAddr is the IP and port on which to listen for incoming events over
+# gRPC. Incoming traffic is expected to be unencrypted, so if using SSL put
+# something like nginx in front to do the decryption.
+# Should be of the form 0.0.0.0:9090
+# Not eligible for live reload.
+GRPCListenAddr: '0.0.0.0:9090'
+
+# PeerListenAddr is the IP and port on which to listen for traffic being
+# rerouted from a peer. Peer traffic is expected to be HTTP, so if using SSL
+# put something like nginx in front to do the decryption. Must be different from
+# ListenAddr
+# Should be of the form 0.0.0.0:8081
+# Not eligible for live reload.
+PeerListenAddr: '0.0.0.0:8081'
+
+# CompressPeerCommunication determines whether refinery will compress span data
+# it forwards to peers. If it costs money to transmit data between refinery
+# instances (e.g. they're spread across AWS availability zones), then you
+# almost certainly want compression enabled to reduce your bill. The option to
+# disable it is provided as an escape hatch for deployments that value lower CPU
+# utilization over data transfer costs.
+CompressPeerCommunication: true
+
+# APIKeys is a list of Honeycomb API keys that the proxy will accept. This list
+# only applies to events - other Honeycomb API actions will fall through to the
+# upstream API directly.
+# Adding keys here causes events arriving with API keys not in this list to be
+# rejected with an HTTP 401 error If an API key that is a literal '*' is in the
+# list, all API keys are accepted.
+# Eligible for live reload.
+APIKeys:
+  - '*'
+
+# HoneycombAPI is the URL for the upstream Honeycomb API.
+# Eligible for live reload.
+HoneycombAPI: 'https://api.honeycomb.io'
+
+# SendDelay is a short timer that will be triggered when a trace is complete.
+# Refinery will wait this duration before actually sending the trace.  The
+# reason for this short delay is to allow for small network delays or clock
+# jitters to elapse and any final spans to arrive before actually sending the
+# trace.  This supports duration strings with supplied units. Set to 0 for
+# immediate sends.
+# Eligible for live reload.
+SendDelay: 2s
+
+# TraceTimeout is a long timer; it represents the outside boundary of how long
+# to wait before sending an incomplete trace. Normally traces are sent when the
+# root span arrives. Sometimes the root span never arrives (due to crashes or
+# whatever), and this timer will send a trace even without having received the
+# root span. If you have particularly long-lived traces you should increase this
+# timer. This supports duration strings with supplied units.
+# Eligible for live reload.
+TraceTimeout: 60s
+
+# SendTicker is a short timer; it determines the duration to use to check for traces to send
+SendTicker: 100ms
+
+# LoggingLevel is the level above which we should log. Debug is very verbose,
+# and should only be used in pre-production environments. Info is the
+# recommended level. Valid options are "debug", "info", "error", and
+# "panic"
+# Not eligible for live reload.
+LoggingLevel: debug
+
+# UpstreamBufferSize and PeerBufferSize control how large of an event queue to use
+# when buffering events that will be forwarded to peers or the upstream API.
+UpstreamBufferSize: 10000
+PeerBufferSize: 10000
+
+############################
+## Implementation Choices ##
+############################
+
+# Each of the config options below chooses an implementation of a Refinery
+# component to use. Depending on the choice there may be more configuration
+# required below in the section for that choice. Changing implementation choices
+# requires a process restart; these changes will not be picked up by a live
+# config reload. (Individual config options for a given implementation may be
+# eligible for live reload).
+
+# Collector describes which collector to use for collecting traces. The only
+# current valid option is "InMemCollector".. More can be added by adding
+# implementations of the Collector interface.
+Collector: InMemCollector
+
+# Logger describes which logger to use for Refinery logs. Valid options are
+# "logrus" and "honeycomb". The logrus option will write logs to STDOUT and the
+# honeycomb option will send them to a Honeycomb dataset.
+Logger: honeycomb
+
+# Metrics describes which service to use for Refinery metrics. Valid options are
+# "prometheus" and "honeycomb". The prometheus option starts a listener that
+# will reply to a request for /metrics. The honeycomb option will send summary
+# metrics to a Honeycomb dataset.
+Metrics: honeycomb
+
+#########################
+## Peer Management     ##
+#########################
+
+PeerManagement:
+  Type: "redis"
+
+  # RedisHost is is used to connect to redis for peer cluster membership management.
+  # Further, if the environment variable 'REFINERY_REDIS_HOST' is set it takes
+  # precedence and this value is ignored.
+  # Not eligible for live reload.
+  RedisHost: "redis:6379"
+
+  # RedisPassword is the password used to connect to redis for peer cluster membership management.
+  # If the environment variable 'REFINERY_REDIS_PASSWORD' is set it takes
+  # precedence and this value is ignored.
+  # Not eligible for live reload.
+  RedisPassword: ""
+
+  # UseTLS enables TLS when connecting to redis for peer cluster membership management, and sets the MinVersion to 1.2.
+  # Not eligible for live reload.
+  UseTLS: false
+
+  # IdentifierInterfaceName is optional. By default, when using RedisHost, Refinery will use
+  # the local hostname to identify itself to other peers in Redis. If your environment
+  # requires that you use IPs as identifiers (for example, if peers can't resolve eachother
+  # by name), you can specify the network interface that Refinery is listening on here.
+  # Refinery will use the first unicast address that it finds on the specified network
+  # interface as its identifier.
+  # Not eligible for live reload.
+  IdentifierInterfaceName: 'eth0'
+
+  # UseIPV6Identifier is optional. If using IdentifierInterfaceName, Refinery will default to the first
+  # IPv4 unicast address it finds for the specified interface. If UseIPV6Identifier is used, will use
+  # the first IPV6 unicast address found.
+  UseIPV6Identifier: false
+
+#########################
+## In-Memory Collector ##
+#########################
+
+# InMemCollector brings together all the settings that are relevant to
+# collecting spans together to make traces.
+InMemCollector:
+
+  # The collection cache is used to collect all spans into a trace as well as
+  # remember the sampling decision for any spans that might come in after the
+  # trace has been marked "complete" (either by timing out or seeing the root
+  # span). The number of traces in the cache should be many multiples (100x to
+  # 1000x) of the total number of concurrently active traces (trace throughput *
+  # trace duration).
+  # Eligible for live reload. Growing the cache capacity with a live config reload
+  # is fine. Avoid shrinking it with a live reload (you can, but it may cause
+  # temporary odd sampling decisions).
+  CacheCapacity: 1000
+
+  # MaxAlloc is optional. If set, it must be an integer >= 0. 64-bit values are
+  # supported.
+  # If set to a non-zero value, once per tick (see SendTicker) the collector
+  # will compare total allocated bytes to this value. If allocation is too
+  # high, cache capacity will be reduced and an error will be logged.
+  # Useful values for this setting are generally in the range of 75%-90% of
+  # available system memory.
+  MaxAlloc: 0
+
+###################
+## Logrus Logger ##
+###################
+
+# LogrusLogger is a section of the config only used if you are using the
+# LogrusLogger to send all logs to STDOUT using the logrus package. If you are
+# using a different logger (eg honeycomb logger) you can leave all this
+# commented out.
+# logrus logger currently has no options!
+LogrusLogger: {}
+
+
+######################
+## Honeycomb Logger ##
+######################
+
+# HoneycombLogger is a section of the config only used if you are using the
+# HoneycombLogger to send all logs to a Honeycomb Dataset. If you are using a
+# different logger (eg file-based logger) you can leave all this commented out.
+HoneycombLogger:
+
+  # LoggerHoneycombAPI is the URL for the upstream Honeycomb API.
+  # Eligible for live reload.
+  LoggerHoneycombAPI: 'https://api.honeycomb.io'
+
+  # LoggerAPIKey is the API key to use to send log events to the Honeycomb logging
+  # dataset. This is separate from the APIKeys used to authenticate regular
+  # traffic.
+  # Eligible for live reload.
+  LoggerAPIKey: abcd1234
+
+  # LoggerDataset is the name of the dataset to which to send Refinery logs
+  # Eligible for live reload.
+  LoggerDataset: Refinery Logs
+
+  # LoggerSamplerEnabled enables a PerKeyThroughput dynamic sampler for log messages.
+  # This will sample log messages based on [log level:message] key on a per second throughput basis.
+  # Not eligible for live reload.
+  LoggerSamplerEnabled: true
+
+  # LoggerSamplerThroughput is the per key per second throughput for the log message dynamic sampler.
+  # Not eligible for live reload.
+  LoggerSamplerThroughput: 10
+
+#######################
+## Honeycomb Metrics ##
+#######################
+
+# HoneycombMetrics is a section of the config only used if you are using the
+# HoneycombMetrics to send all metrics to a Honeycomb Dataset. If you are using a
+# different metrics service (eg prometheus or metricsd) you can leave all this
+# commented out.
+HoneycombMetrics:
+
+  # MetricsHoneycombAPI is the URL for the upstream Honeycomb API.
+  # Eligible for live reload.
+  MetricsHoneycombAPI: 'https://api.honeycomb.io'
+
+  # MetricsAPIKey is the API key to use to send log events to the Honeycomb logging
+  # dataset. This is separate from the APIKeys used to authenticate regular
+  # traffic.
+  # Eligible for live reload.
+  MetricsAPIKey: abcd1234
+
+  # MetricsDataset is the name of the dataset to which to send Refinery metrics
+  # Eligible for live reload.
+  MetricsDataset: Refinery Metrics
+
+  # MetricsReportingInterval is the frequency (in seconds) to send metric events
+  # to Honeycomb. Between 1 and 60 is recommended.
+  # Not eligible for live reload.
+  MetricsReportingInterval: 3
+
+########################
+## Prometheus Metrics ##
+########################
+PrometheusMetrics:
+
+  # MetricsListenAddr determines the interface and port on which Prometheus will
+  # listen for requests for /metrics. Must be different from the main Refinery
+  # listener.
+  # Not eligible for live reload.
+  MetricsListenAddr: "0.0.0.0:8888"

--- a/charts/refinery/sample-configs/rules_complete.yaml
+++ b/charts/refinery/sample-configs/rules_complete.yaml
@@ -1,0 +1,235 @@
+############################
+## Sampling Rules Config ##
+############################
+
+# DryRun - If enabled, marks traces that would be dropped given current sampling rules,
+# and sends all traces regardless
+DryRun: false
+
+# DryRunFieldName - the key to add to use to add to event data when using DryRun mode above, defaults to refinery_kept
+# DryRunFieldName = "refinery_kept"
+
+# DeterministicSampler is a section of the config for manipulating the
+# Deterministic Sampler implementation. This is the simplest sampling algorithm
+# - it is a static sample rate, choosing traces randomly to either keep or send
+# (at the appropriate rate). It is not influenced by the contents of the trace.
+Sampler: DeterministicSampler
+
+# SampleRate is the rate at which to sample. It indicates a ratio, where one
+# sample trace is kept for every n traces seen. For example, a SampleRate of 30
+# will keep 1 out of every 30 traces. The choice on whether to keep any specific
+# trace is random, so the rate is approximate.
+# Eligible for live reload.
+SampleRate: 1
+
+############################
+## Dataset sampling rules ##
+############################
+
+# Note: If your dataset name contains a space, you will have to escape the dataset name
+# using single quotes, such as "dataset 1":
+dataset1:
+
+  # DynamicSampler is a section of the config for manipulating the simple Dynamic Sampler
+  # implementation. This sampler collects the values of a number of fields from a
+  # trace and uses them to form a key. This key is handed to the standard dynamic
+  # sampler algorithm which generates a sample rate based on the frequency with
+  # which that key has appeared in the previous ClearFrequencySec seconds. See
+  # https://github.com/honeycombio/dynsampler-go for more detail on the mechanics
+  # of the dynamic sampler.  This sampler uses the AvgSampleRate algorithm from
+  # that package.
+  Sampler: DynamicSampler
+
+  # SampleRate is the goal rate at which to sample. It indicates a ratio, where
+  # one sample trace is kept for every n traces seen. For example, a SampleRate of
+  # 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+  # sampler, who assigns a sample rate for each trace based on the fields selected
+  # from that trace.
+  # Eligible for live reload.
+  SampleRate: 2
+
+  # FieldList is a list of all the field names to use to form the key that will be
+  # handed to the dynamic sampler. The cardinality of the combination of values
+  # from all of these keys should be reasonable in the face of the frequency of
+  # those keys. If the combination of fields in these keys essentially makes them
+  # unique, the dynamic sampler will do no sampling.  If the keys have too few
+  # values, you won't get samples of the most interesting traces. A good key
+  # selection will have consistent values for high frequency boring traffic and
+  # unique values for outliers and interesting traffic. Including an error field
+  # (or something like HTTP status code) is an excellent choice. As an example,
+  # assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+  # would be a good set of keys in order to let you see accurately use of all
+  # endpoints and call out when there is failing traffic to any endpoint. Field
+  # names may come from any span in the trace.
+  # Eligible for live reload.
+  FieldList:
+    - request.method
+    - response.status_code
+
+  # UseTraceLength will add the number of spans in the trace in to the dynamic
+  # sampler as part of the key. The number of spans is exact, so if there are
+  # normally small variations in trace length you may want to leave this off. If
+  # traces are consistent lengths and changes in trace length is a useful
+  # indicator of traces you'd like to see in Honeycomb, set this to true.
+  # Eligible for live reload.
+  UseTraceLength: true
+
+  # AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+  # to the root span of the trace containing the key used by the sampler to decide
+  # the sample rate. This can be helpful in understanding why the sampler is
+  # making certain decisions about sample rate and help you understand how to
+  # better choose the sample rate key (aka the FieldList setting above) to use.
+  AddSampleRateKeyToTrace: true
+
+  # AddSampleRateKeyToTraceField is the name of the field the sampler will use
+  # when adding the sample rate key to the trace. This setting is only used when
+  # AddSampleRateKeyToTrace is true.
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+
+  # ClearFrequencySec is the name of the field the sampler will use to determine
+  # the period over which it will calculate the sample rate. This setting defaults
+  # to 30.
+  # Eligible for live reload.
+  ClearFrequencySec: 60
+
+dataset2:
+
+  # EMADynamicSampler is a section of the config for manipulating the Exponential
+  # Moving Average (EMA) Dynamic Sampler implementation. Like the simple DynamicSampler,
+  # it attempts to average a given sample rate, weighting rare traffic and frequent
+  # traffic differently so as to end up with the correct average.
+  #
+  # EMADynamicSampler is an improvement upon the simple DynamicSampler and is recommended
+  # for most use cases. Based on the DynamicSampler implementation, EMADynamicSampler differs
+  # in that rather than compute rate based on a periodic sample of traffic, it maintains an Exponential
+  # Moving Average of counts seen per key, and adjusts this average at regular intervals.
+  # The weight applied to more recent intervals is defined by `weight`, a number between
+  # (0, 1) - larger values weight the average more toward recent observations. In other words,
+  # a larger weight will cause sample rates more quickly adapt to traffic patterns,
+  # while a smaller weight will result in sample rates that are less sensitive to bursts or drops
+  # in traffic and thus more consistent over time.
+  #
+  # Keys that are not found in the EMA will always have a sample
+  # rate of 1. Keys that occur more frequently will be sampled on a logarithmic
+  # curve. In other words, every key will be represented at least once in any
+  # given window and more frequent keys will have their sample rate
+  # increased proportionally to wind up with the goal sample rate.
+  Sampler: EMADynamicSampler
+
+  # GoalSampleRate is the goal rate at which to sample. It indicates a ratio, where
+  # one sample trace is kept for every n traces seen. For example, a SampleRate of
+  # 30 will keep 1 out of every 30 traces. This rate is handed to the dynamic
+  # sampler, who assigns a sample rate for each trace based on the fields selected
+  # from that trace.
+  # Eligible for live reload.
+  GoalSampleRate: 2
+
+  # FieldList is a list of all the field names to use to form the key that will be
+  # handed to the dynamic sampler. The cardinality of the combination of values
+  # from all of these keys should be reasonable in the face of the frequency of
+  # those keys. If the combination of fields in these keys essentially makes them
+  # unique, the dynamic sampler will do no sampling.  If the keys have too few
+  # values, you won't get samples of the most interesting traces. A good key
+  # selection will have consistent values for high frequency boring traffic and
+  # unique values for outliers and interesting traffic. Including an error field
+  # (or something like HTTP status code) is an excellent choice. As an example,
+  # assuming 30 or so endpoints, a combination of HTTP endpoint and status code
+  # would be a good set of keys in order to let you see accurately use of all
+  # endpoints and call out when there is failing traffic to any endpoint. Field
+  # names may come from any span in the trace.
+  # Eligible for live reload.
+  FieldList:
+    - request.method
+    - response.status_code
+
+  # UseTraceLength will add the number of spans in the trace in to the dynamic
+  # sampler as part of the key. The number of spans is exact, so if there are
+  # normally small variations in trace length you may want to leave this off. If
+  # traces are consistent lengths and changes in trace length is a useful
+  # indicator of traces you'd like to see in Honeycomb, set this to true.
+  # Eligible for live reload.
+  UseTraceLength: true
+
+  # AddSampleRateKeyToTrace when this is set to true, the sampler will add a field
+  # to the root span of the trace containing the key used by the sampler to decide
+  # the sample rate. This can be helpful in understanding why the sampler is
+  # making certain decisions about sample rate and help you understand how to
+  # better choose the sample rate key (aka the FieldList setting above) to use.
+  AddSampleRateKeyToTrace: true
+
+  # AddSampleRateKeyToTraceField is the name of the field the sampler will use
+  # when adding the sample rate key to the trace. This setting is only used when
+  # AddSampleRateKeyToTrace is true.
+  AddSampleRateKeyToTraceField: meta.refinery.dynsampler_key
+
+  # AdjustmentInterval defines how often (in seconds) we adjust the moving average from
+  # recent observations. Default 15s
+  # Eligible for live reload.
+  AdjustmentInterval: 15
+
+  # Weight is a value between (0, 1) indicating the weighting factor used to adjust
+  # the EMA. With larger values, newer data will influence the average more, and older
+  # values will be factored out more quickly.  In mathematical literature concerning EMA,
+  # this is referred to as the `alpha` constant.
+  # Default is 0.5
+  # Eligible for live reload.
+  Weight: 0.5
+
+  # MaxKeys, if greater than 0, limits the number of distinct keys tracked in EMA.
+  # Once MaxKeys is reached, new keys will not be included in the sample rate map, but
+  # existing keys will continue to be be counted. You can use this to keep the sample rate
+  # map size under control.
+  # Eligible for live reload
+  MaxKeys: 0
+
+  # AgeOutValue indicates the threshold for removing keys from the EMA. The EMA of any key
+  # will approach 0 if it is not repeatedly observed, but will never truly reach it, so we have to
+  # decide what constitutes "zero". Keys with averages below this threshold will be removed
+  # from the EMA. Default is the same as Weight, as this prevents a key with the smallest
+  # integer value (1) from being aged out immediately. This value should generally be <= Weight,
+  # unless you have very specific reasons to set it higher.
+  # Eligible for live reload
+  AgeOutValue: 0.5
+
+  # BurstMultiple, if set, is multiplied by the sum of the running average of counts to define
+  # the burst detection threshold. If total counts observed for a given interval exceed the threshold
+  # EMA is updated immediately, rather than waiting on the AdjustmentInterval.
+  # Defaults to 2; negative value disables. With a default of 2, if your traffic suddenly doubles,
+  # burst detection will kick in.
+  # Eligible for live reload
+  BurstMultiple: 2.0
+
+  # BurstDetectionDelay indicates the number of intervals to run after Start is called before
+  # burst detection kicks in.
+  # Defaults to 3
+  # Eligible for live reload
+  BurstDetectionDelay: 3
+
+dataset3:
+  Sampler: DeterministicSampler
+  SampleRate: 10
+
+dataset4:
+  Sampler: RulesBasedSampler
+  rule:
+    - name: 500 errors
+      SampleRate: 1
+      condition:
+        - field: status_code
+          operator: '='
+          value: 500
+        - field: duration_ms
+          operator: '>='
+          value: 1000.789
+    - name: drop 200 responses
+      drop: true
+      condition:
+        - field: status_code
+          operator: '='
+          value: 200
+    - SampleRate: 10 # default when no rules match
+
+dataset5:
+  Sampler: TotalThroughputSampler
+  GoalThroughputPerSec: 100
+  FieldList: '[request.method]'


### PR DESCRIPTION
Includes YAML equivalents of the config_complete.toml and rules_comlete.toml files from the Refinery repo

These files are meant to be used as examples for users.