### PR TITLE
[refinery] - enable port 4317 for OTLP

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -145,7 +145,8 @@ The following table lists the configurable parameters of the Refinery chart and 
 | `podSecurityContext` | Security context for pod | `{}` |
 | `securityContext` | Security context for container | `{}` |
 | `service.type` | Kubernetes Service type | `ClusterIP` |
-| `service.port` | Service port | `80` |
+| `service.port` | Service port for data in Honeycomb format | `80` |
+| `service.grpcPort` | Service port for data in OTLP format over gRPC | `4317` |
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |

--- a/charts/refinery/sample-configs/config_complete.yaml
+++ b/charts/refinery/sample-configs/config_complete.yaml
@@ -12,9 +12,9 @@ ListenAddr: '0.0.0.0:8080'
 # GRPCListenAddr is the IP and port on which to listen for incoming events over
 # gRPC. Incoming traffic is expected to be unencrypted, so if using SSL put
 # something like nginx in front to do the decryption.
-# Should be of the form 0.0.0.0:9090
+# Should be of the form 0.0.0.0:4317
 # Not eligible for live reload.
-GRPCListenAddr: '0.0.0.0:9090'
+GRPCListenAddr: '0.0.0.0:4317'
 
 # PeerListenAddr is the IP and port on which to listen for traffic being
 # rerouted from a peer. Peer traffic is expected to be HTTP, so if using SSL
@@ -253,4 +253,4 @@ PrometheusMetrics:
   # listen for requests for /metrics. Must be different from the main Refinery
   # listener.
   # Not eligible for live reload.
-  MetricsListenAddr: "0.0.0.0:8888"
+  MetricsListenAddr: "0.0.0.0:9090"

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - name: data
               containerPort: 8080
               protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
             - name: peer
               containerPort: 8081
               protocol: TCP

--- a/charts/refinery/templates/service.yaml
+++ b/charts/refinery/templates/service.yaml
@@ -15,6 +15,10 @@ spec:
       targetPort: data
       protocol: TCP
       name: data
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
     {{- if eq .Values.config.Metrics "prometheus" }}
     - port: 9090
       targetPort: metrics

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -27,6 +27,7 @@ environment: [ ]
 # Values used to build config.yaml
 config:
   ListenAddr: 0.0.0.0:8080
+  GRPCListenAddr: 0.0.0.0:4317
   PeerListenAddr: 0.0.0.0:8081
   HoneycombAPI: https://api.honeycomb.io
   LoggingLevel: error
@@ -101,6 +102,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 80
+  grpcPort: 4317
   annotations: {}
 
 ingress:


### PR DESCRIPTION
This will enable by default port 4317 for incoming OTLP traffic (using gRPC).  

4317 was chosen because that is what the OpenTelemetry Collector is moving towards for receiving OTLP traffic over grpc. 

This will also clear up potential confusion over using the same port as the Prometheus metrics receiver, as previously referenced in the sample config.
