### PR TITLE
[opentelemetry-collector] - use OTLP exporter

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.3.2
-appVersion: 0.22.0
+version: 0.4.0
+appVersion: 0.25.0
 keywords:
   - observability
   - tracing

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -1,10 +1,11 @@
 # OpenTelemetry Collector for Honeycomb
 
-[OpenTelemetry](https://opentelemetry.io) provides a single set of APIs, libraries, agents, and collector services to capture distributed traces and metrics from your application. 
+[OpenTelemetry](https://opentelemetry.io) provides a single set of APIs, libraries, agents, and collector services to 
+capture distributed traces and metrics from your application. 
 [Honeycomb](https://honeycomb.io) is built for modern dev teams to see and understand how their production systems are 
 behaving. Our goal is to give engineers the observability they need to eliminate toil and delight their users.
-This helm chart will install the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib) with the
-Honeycomb exporter configured.
+This helm chart will install the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector-contrib) 
+with the OTLP exporter configured to send data to Honeycomb.
 
 ## TL;DR;
 ```bash
@@ -17,11 +18,12 @@ helm install opentelemetry-collector honeycomb/opentelemetry-collector --set hon
 
 ## Installing the Chart
 ### Using default configuration
-By default this chart will deploy an OpenTelemetry Collector as a single replica. A single pipeline will be configured for traces as follows:
+By default this chart will deploy an OpenTelemetry Collector as a single replica. A single pipeline will be configured 
+for traces as follows:
 ```yaml
     receivers: [otlp, jaeger, zipkin]
-    processors: [memory_limiter, batch, queued_retry]
-    exporters: [honeycomb]
+    processors: [memory_limiter, batch]
+    exporters: [otlp]
 ```
 
 ```bash
@@ -39,7 +41,10 @@ helm install opentelemetry-collector honeycomb/opentelemetry-collector \
 ```
 
 ### Using modified collector configuration
-The collector's configuration can be overriden via this chart's `config` property. You only need to specify properties that you want to override. Make sure to override the `service` section if you want to add or remove receivers, processors, or exporters. Create a yaml file with your Honeycomb API key and custom collector configuration. This example will add a Jager exporter to the configuration.
+The collector's configuration can be overridden via this chart's `config` property. You only need to specify properties 
+that you want to override. Make sure to override the `service` section if you want to add or remove receivers, processors, 
+or exporters. Create a yaml file with your Honeycomb API key and custom collector configuration. This example will add a 
+Jaeger exporter to the configuration.
 ```yaml
 honeycomb:
   apiKey: YOUR_API_KEY
@@ -51,21 +56,24 @@ config:
   service:
     pipelines:
       traces:
-        exporters: [honeycomb, jaeger]
+        exporters: [otlp, jaeger]
 ```
 Then use this yaml file when installing the chart
 ```bash
 helm repo add honeycomb https://honeycombio.github.io/helm-charts
 helm install opentelemetry-collector honeycomb/opentelemetry-collector --values my-values-file.yaml
 ```
-See [design docs](https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md) for more information on the OpenTelemetry Collector configuration.
+See [design docs](https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md) for more 
+information on the OpenTelemetry Collector configuration.
 
 ## Configuration
 
 The [values.yaml](./values.yaml) file contains information about all configuration
 options for this chart.
 
-The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource with your API Key specified in the `api-key` field. 
+The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting 
+`honeycomb.existingSecret` to the name of an existing opaque secret resource with your API Key specified in the `api-key` 
+field. 
 
 You can obtain your API Key by going to your Account profile page inside of your Honeycomb instance.
 
@@ -76,11 +84,9 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | Parameter | Description | Default |
 | --- | --- | --- |
 | `honeycomb.apiKey` | Honeycomb API Key | `YOUR_API_KEY` |
-| `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
+| `honeycomb.apiHost` | API URL to sent events to. This is the Honeycomb OTLP over gRPC endpoint. | `api.honeycomb.io:443` |
 | `honeycomb.dataset` | Name of dataset to send data into | `opentelemetry-collector` |
 | `honeycomb.existingSecret` | Name of an existing secret resource to use containing your API Key in the `api-key` field | `nil` |
-| `honeycomb.sample_rate` | Constant sample rate. Can be used to send 1 / x events to Honeycomb. Defaults to 1 (always sample) | `1` |
-| `honeycomb.sample_rate_attribute` | The name of an attribute that contains the sample_rate for each span. | `nil` |
 | `config` | OpenTelemetry Collector Configuration ([design docs](https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md)) | receivers: [otlp, jaeger, zipkin] / processors: [memory_limiter, batch, queued_retry] / exporters: [honeycomb] |
 | `nameOverride` | String to partially override opentelemetry-collector.fullname template with a string (will append the release name) | `nil` |
 | `fullnameOverride` | String to fully override opentelemetry-collector.fullname template with a string | `nil` |
@@ -112,5 +118,17 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 
 ## Upgrading
 
+### Upgrading from 0.3.2 or earlier.
+The Honeycomb exporter has been deprecated in favor of using the OTLP exporter that the Honeycomb service supports natively. 
+Since the default OTLP exporter is now used, sampling of data on export is no longer supported, and use of the 
+`honeycomb.sample_rate` and `honeycomb.sample_rate_attribute` properties is no longer supported. 
+Sampling can be accomplished using the [Probabilistic Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/probabilisticsamplerprocessor).
+Advanced sampling techniques can be accomplished using the [Honeycomb Refinery](../refinery) Helm chart.
+
+The default value for the `honeycomb.apiHost` property has changed to represent a gRPC endpoint address. 
+If you copied this default value into your local values file, you will need to update this to `api.honeycomb.io:443` when upgrading.
+
 ### Upgrading from 0.1.1 or earlier.
-A breaking change in the OTLP receiver configuration was introduced. This change is part of the default configuration. If you changed the default OTLP receiver configuration, you will need to ensure your changes are compatible with the updated configuration layout for OTLP.
+A breaking change in the OTLP receiver configuration was introduced. This change is part of the default configuration. 
+If you changed the default OTLP receiver configuration, you will need to ensure your changes are compatible with the 
+updated configuration layout for OTLP.

--- a/charts/opentelemetry-collector/templates/configmap.yaml
+++ b/charts/opentelemetry-collector/templates/configmap.yaml
@@ -17,12 +17,12 @@ data:
     {{- end }}
 
     exporters:
-      honeycomb:
-        api_key: ${HONEYCOMB_API_KEY}
-        api_url: {{ .Values.honeycomb.apiHost }}
-        dataset: {{ .Values.honeycomb.dataset }}
-        sample_rate: {{ .Values.honeycomb.sample_rate }}
-        sample_rate_attribute: {{ .Values.honeycomb.sample_rate_attribute }}
+      otlp:
+        endpoint: {{ .Values.honeycomb.apiHost }}
+        headers:
+          "x-honeycomb-team": "${HONEYCOMB_API_KEY}"
+          "x-honeycomb-dataset": "{{ .Values.honeycomb.dataset }}"
+
     {{- if .Values.config.exporters }}
     {{- toYaml .Values.config.exporters | nindent 6 }}
     {{- end }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -6,13 +6,11 @@ honeycomb:
   # Specify your Honeycomb API KEY to send events
   apiKey: YOUR_API_KEY
   # Specify host URL to send all events to
-  apiHost: https://api.honeycomb.io/
+  apiHost: api.honeycomb.io:443
   # Specify the name of the dataset to send data to
   dataset: opentelemetry-collector
   # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
   # existingSecret:
-  # (Optional): Constant sample rate. Can be used to send 1 / x events to Honeycomb. Defaults to 1 (always sample).
-  # sample_rate: 1
 
 
 config:
@@ -24,6 +22,8 @@ config:
     jaeger:
       protocols:
         grpc:
+        thrift_binary:
+        thrift_compact:
         thrift_http:
     zipkin:
 
@@ -49,7 +49,7 @@ config:
       traces:
         receivers: [otlp, jaeger, zipkin]
         processors: [memory_limiter, batch]
-        exporters: [honeycomb]
+        exporters: [otlp]
 
 
 nameOverride: ""


### PR DESCRIPTION
Removes the old Honeycomb exporter in favor of the OTLP exporter.

This is a potentially breaking upgrade for people that use sample_rate or sample_rate_attribute.  That logic will need to get moved to the Otel sampling processor or Honeycomb Refinery.

Given the potential breaking change, this warranted a minor version bump.

The default config for the collector will now look like this: 
```
receivers:
  jaeger:
    protocols:
      grpc: null
      thrift_binary: null
      thrift_compact: null
      thrift_http: null
  otlp:
    protocols:
      grpc: null
      http: null
  zipkin: null

processors:
  batch: null
  memory_limiter:
    ballast_size_mib: 683
    check_interval: 5s
    limit_mib: 400
    spike_limit_mib: 100

exporters:
  otlp:
    endpoint: api.honeycomb.io:443
    headers:
      "x-honeycomb-team": "${HONEYCOMB_API_KEY}"
      "x-honeycomb-dataset": "opentelemetry-collector"

extensions:
  health_check:
    port: 13133

service:
  extensions:
    - health_check
  pipelines:
    traces:
      exporters:
        - otlp
      processors:
        - memory_limiter
        - batch
      receivers:
        - otlp
        - jaeger
        - zipkin
```