### PR TITLE
[refinery] - redis service port name

### DIFF
--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -31,7 +31,7 @@ spec:
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
           ports:
-            - name: http
+            - name: redis
               containerPort: 6379
               protocol: TCP
       {{- with .Values.nodeSelector }}

--- a/charts/refinery/templates/service-redis.yaml
+++ b/charts/refinery/templates/service-redis.yaml
@@ -8,10 +8,10 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - name: http
+    - name: tcp-redis
       port: 6379
       protocol: TCP
-      targetPort: 6379
+      targetPort: redis
   selector:
     {{- include "refinery.redis.selectorLabels" . | nindent 4 }}
 {{- end}}


### PR DESCRIPTION
Updates the service port name for Redis to properly represent its use.  Fixes #42 