### PR TITLE
Change jaeger thrift ports

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: 0.25.0
 keywords:
   - observability

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -108,12 +108,12 @@ ports: # configures both service, and deployment
     enabled: true
     containerPort: 6832
     servicePort: 6832
-    protocol: TCP
+    protocol: UDP
   jaeger-compact:
     enabled: true
     containerPort: 6831
     servicePort: 6831
-    protocol: TCP
+    protocol: UDP
   jaeger-grpc:
     enabled: true
     containerPort: 14250


### PR DESCRIPTION
Change the protocol for jaeger-compact and jaeger-binary to
UDP from TCP.

Ref: https://www.jaegertracing.io/docs/1.22/getting-started/