### PR TITLE
[opentelemetry-collector] - expose exporter options for OTLP

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.4.1
-appVersion: 0.25.0
+version: 0.4.2
+appVersion: 0.27.0
 keywords:
   - observability
   - tracing

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `honeycomb.apiHost` | API URL to sent events to. This is the Honeycomb OTLP over gRPC endpoint. | `api.honeycomb.io:443` |
 | `honeycomb.dataset` | Name of dataset to send data into | `opentelemetry-collector` |
 | `honeycomb.existingSecret` | Name of an existing secret resource to use containing your API Key in the `api-key` field | `nil` |
+| `honeycomb.exportOptions` | Configuration options for the OpenTelemetry [OTLP exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configgrpc/README.md) used to export data into Honeycomb. All options but `endpoint` and `headers` can be used. | `nil` |
 | `config` | OpenTelemetry Collector Configuration ([design docs](https://github.com/open-telemetry/opentelemetry-collector/blob/master/docs/design.md)) | receivers: [otlp, jaeger, zipkin] / processors: [memory_limiter, batch, queued_retry] / exporters: [honeycomb] |
 | `nameOverride` | String to partially override opentelemetry-collector.fullname template with a string (will append the release name) | `nil` |
 | `fullnameOverride` | String to fully override opentelemetry-collector.fullname template with a string | `nil` |

--- a/charts/opentelemetry-collector/templates/configmap.yaml
+++ b/charts/opentelemetry-collector/templates/configmap.yaml
@@ -22,6 +22,9 @@ data:
         headers:
           "x-honeycomb-team": "${HONEYCOMB_API_KEY}"
           "x-honeycomb-dataset": "{{ .Values.honeycomb.dataset }}"
+        {{- if .Values.honeycomb.exportOptions }}
+        {{- toYaml .Values.honeycomb.exportOptions | nindent 8 }}
+        {{- end }}
 
     {{- if .Values.config.exporters }}
     {{- toYaml .Values.config.exporters | nindent 6 }}

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -11,9 +11,10 @@ honeycomb:
   dataset: opentelemetry-collector
   # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
   # existingSecret:
-  exportOptions:
-    insecure: true
-    balancer_name: round_robin
+  # Use this to specify options for the OTLP exporter, such as insecure, or balancer_name.
+  # exportOptions:
+  #   insecure: true
+  #   balancer_name: round_robin
 
 
 config:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -11,6 +11,9 @@ honeycomb:
   dataset: opentelemetry-collector
   # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
   # existingSecret:
+  exportOptions:
+    insecure: true
+    balancer_name: round_robin
 
 
 config:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -12,6 +12,7 @@ honeycomb:
   # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
   # existingSecret:
   # Use this to specify options for the OTLP exporter, such as insecure, or balancer_name.
+  # All export options except for endpoint, and headers can be specified.
   # exportOptions:
   #   insecure: true
   #   balancer_name: round_robin


### PR DESCRIPTION
Exposes export options for the default OTLP exporter. All OTLP exporter options but `endpoint` and `headers` can be specified.

Fixes #48 