### PR TITLE
[secure-tenancy] add otlp over grpc support

### DIFF
--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: secure-tenancy
 description: Honeycomb Secure Tenancy
 version: 0.1.4
-appVersion: 1.7.0
+appVersion: 1.8.2
 keywords:
   - observability
   - security

--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: secure-tenancy
 description: Honeycomb Secure Tenancy
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.7.0
 keywords:
   - observability

--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: secure-tenancy
 description: Honeycomb Secure Tenancy
 version: 0.1.4
-appVersion: 1.8.2
+appVersion: 1.9.1
 keywords:
   - observability
   - security

--- a/charts/secure-tenancy/README.md
+++ b/charts/secure-tenancy/README.md
@@ -100,7 +100,8 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `mysql.rootUser.password` | When `mysql.enabled` is true this will be the root password used | `root_password` |
 | `mysql.replication.password` | When `mysql.enabled` is true this will be the replication password used | `replication_password` |
 | `service.type` | Kubernetes Service type | `ClusterIP` |
-| `service.port` | Service HTTP port | `80` |
+| `service.port` | Service port for Honeycomb formatted telemetry | `80` |
+| `service.grpcPort` | Service port for OTLP over GRPC telemetry | `4317` |
 | `service.ip` | LoadBalancer service IP address | `nil` |
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |

--- a/charts/secure-tenancy/README.md
+++ b/charts/secure-tenancy/README.md
@@ -75,6 +75,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | --- | --- | --- |
 | `honeycomb.authToken` | Honeycomb Secure Tenancy authorization token | `YOUR_AUTH_TOKEN` |
 | `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
+| `honeycomb.grpcApiHost` | API URL for OTLP over GRPC to sent events to. Must include port. | `https://api.honeycomb.io:443` |
 | `honeycomb.uiBaseUrl` | URL used to access Honeycomb UI | `https://ui.honeycomb.io` |
 | `honeycomb.maxIdleConnsPerHost` | Maximum # of Idle connections to MySQL database | `100` |
 | `honeycomb.hsts.enabled` | Wether or not to enable HTTP Strict Transport Security | `false` |

--- a/charts/secure-tenancy/README.md
+++ b/charts/secure-tenancy/README.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | --- | --- | --- |
 | `honeycomb.authToken` | Honeycomb Secure Tenancy authorization token | `YOUR_AUTH_TOKEN` |
 | `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
-| `honeycomb.grpcApiHost` | API URL for OTLP over GRPC to sent events to. Must include port. | `https://api.honeycomb.io:443` |
+| `honeycomb.grpcApiHost` | API URL for OTLP over gRPC to sent events to. Must include port. | `https://api.honeycomb.io:443` |
 | `honeycomb.uiBaseUrl` | URL used to access Honeycomb UI | `https://ui.honeycomb.io` |
 | `honeycomb.maxIdleConnsPerHost` | Maximum # of Idle connections to MySQL database | `100` |
 | `honeycomb.hsts.enabled` | Wether or not to enable HTTP Strict Transport Security | `false` |
@@ -102,7 +102,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `mysql.replication.password` | When `mysql.enabled` is true this will be the replication password used | `replication_password` |
 | `service.type` | Kubernetes Service type | `ClusterIP` |
 | `service.port` | Service port for Honeycomb formatted telemetry | `80` |
-| `service.grpcPort` | Service port for OTLP over GRPC telemetry | `4317` |
+| `service.grpcPort` | Service port for OTLP over gRPC telemetry | `4317` |
 | `service.ip` | LoadBalancer service IP address | `nil` |
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |

--- a/charts/secure-tenancy/templates/configmap.yaml
+++ b/charts/secure-tenancy/templates/configmap.yaml
@@ -13,7 +13,8 @@ data:
     http_strict_transport_security_enabled: {{ .Values.honeycomb.hsts.enabled }}
     http_strict_transport_security_max_age: {{ .Values.honeycomb.hsts.maxAge }}
     max_idle_conns_per_host: {{ .Values.honeycomb.maxIdleConnsPerHost }}
-    grpc_base_url: 0.0.0.0:8081
+    grpc_listen_addr: 8081
+    api_grpc_base_url: {{ .Values.honeycomb.grpcApiHost | quote }}
   mysqlconfig.yaml: |
     host: "{{ include "db.fullhost" . }}"
     database: {{ .Values.mysql.db.name | quote }}

--- a/charts/secure-tenancy/templates/configmap.yaml
+++ b/charts/secure-tenancy/templates/configmap.yaml
@@ -13,6 +13,7 @@ data:
     http_strict_transport_security_enabled: {{ .Values.honeycomb.hsts.enabled }}
     http_strict_transport_security_max_age: {{ .Values.honeycomb.hsts.maxAge }}
     max_idle_conns_per_host: {{ .Values.honeycomb.maxIdleConnsPerHost }}
+    grpc_base_url: 0.0.0.0:8081
   mysqlconfig.yaml: |
     host: "{{ include "db.fullhost" . }}"
     database: {{ .Values.mysql.db.name | quote }}

--- a/charts/secure-tenancy/templates/deployment.yaml
+++ b/charts/secure-tenancy/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: grpc
+              containerPort: 8081
+              protocol: TCP
           volumeMounts:
           - name: config
             mountPath: /config

--- a/charts/secure-tenancy/templates/service.yaml
+++ b/charts/secure-tenancy/templates/service.yaml
@@ -18,5 +18,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     {{- include "secure-tenancy.selectorLabels" . | nindent 4 }}

--- a/charts/secure-tenancy/values.yaml
+++ b/charts/secure-tenancy/values.yaml
@@ -4,6 +4,7 @@ honeycomb:
   authToken: YOUR_AUTH_TOKEN
   # Specify host URL to send Honeycomb format events to
   apiHost: https://api.honeycomb.io
+  grpcApiHost: https://api.honeycomb.io:443
 
   uiBaseUrl: https://ui.honeycomb.io
   

--- a/charts/secure-tenancy/values.yaml
+++ b/charts/secure-tenancy/values.yaml
@@ -2,9 +2,9 @@
 honeycomb:
   # Specify Auth Token used for Secure Tenancy
   authToken: YOUR_AUTH_TOKEN
-  # Specify host URL to send all events to
+  # Specify host URL to send Honeycomb format events to
   apiHost: https://api.honeycomb.io
-  
+
   uiBaseUrl: https://ui.honeycomb.io
   
   maxIdleConnsPerHost: 100
@@ -76,6 +76,7 @@ service:
   annotations: {}
   type: ClusterIP
   port: 80
+  grpcPort: 4317
   # If using a LoadBalancer service, you may also want to specify the IP to use
   # ip: 
 


### PR DESCRIPTION
Adds support to ingest OTLP over GRPC ingest into Secure Tenancy.

Closes #49 