### PR TITLE
[agent] - add support for priorityClassName

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.0.3
+version: 1.0.4
 appVersion: 2.1.3
 keywords:
   - observability

--- a/charts/honeycomb/README.md
+++ b/charts/honeycomb/README.md
@@ -105,6 +105,7 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `nodeSelector` | Node labels for pod assignment | `{}` | 
 | `tolerations` | Tolerations for pod assignment | `[]`| 
 | `affinity` | Map of node/pod affinities | `{}` |
+| `priorityClassName` | Pod priority for Honeycomb agent | `nil` |
 | `rbac.create` | Specify whether RBAC resources should be created and used | `true` |
 | `serviceAccount.create` | Specify whether a ServiceAccount should be created | `true` |
 | `serviceAccount.name` | The name of the ServiceAccount to create | Generated using the `honeycomb.fullname` template |

--- a/charts/honeycomb/templates/daemonset.yaml
+++ b/charts/honeycomb/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
       labels:
         {{- include "honeycomb.agent.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -86,6 +86,9 @@ tolerations:
 
 affinity: {}
 
+## Optional priorityClassName for Honeycomb Agent
+priorityClassName: ""
+
 rbac:
   # Specifies whether roles based access control rules should be created.
   create: true


### PR DESCRIPTION
Adds support for [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to agent daemonset.

Closes #45 