### PR TITLE
[refinery] - support pod scheduling specific for redis 

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 1.1.1
-appVersion: 1.4.0
+version: 1.1.2
+appVersion: 1.4.1
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -108,8 +108,19 @@ are largely based on the velocity of spans received per second, and the average 
 such as rule complexity and trace duration timeouts will also have an effect on scaling requirements.
 
 The primary setting that control scaling are `replicaCount` and `resources.limits`. When changing `resources.limits.memory`,
-you must also change `config.InMemCollector.MaxAlloc`. This should be set to 75-90% of the available memory for each replica.
+you must also change `config.InMemCollector.MaxAlloc`. This should be set to 80% of the available memory for each replica.
 Refer to the comments in [values.yaml](./values.yaml) for more details about each property.
+
+See [Refinery: Scale and Troubleshoot](https://docs.honeycomb.io/manage-data-volume/refinery/scale-and-troubleshoot/)
+for more details on how to properly scale Refinery.
+
+## Redis Configuration
+
+By default, a single node configuration of Redis will be installed. This configuration **is not** recommended for 
+production deployments of Refinery. It is recommended that you configure and install a high available setup of Redis 
+that can be used by this chart with the `redis.existingHost` parameter. 
+
+Redis is used for peer discovery only, and the workloads on an existing cluster will be minimal.
 
 ## Configuration
 
@@ -158,6 +169,9 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `redis.image.repository` | Redis image name | `redis` |
 | `redis.image.tag` | Redis image tag | `6.0.2` |
 | `redis.image.pullPolicy` | Redis image pull policy | `IfNotPresent` |
+| `redis.nodeSelector` | Node labels for pod assignment specific to the installed Redis deployment | `{}` |
+| `redis.tolerations` | Tolerations for pod assignment specific to the installed Redis deployment | `[]`|
+| `redis.affinity` | Map of node/pod affinities specific to the installed Redis deployment | `{}` |
 | `serviceAccount.create` | Specify whether a ServiceAccount should be created | `true` |
 | `serviceAccount.name` | The name of the ServiceAccount to create | Generated using the `refinery.fullname` template |
 | `serviceAccount.annotations` | Annotations to be applied to ServiceAccount | `{}` |

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -34,15 +34,15 @@ spec:
             - name: redis
               containerPort: 6379
               protocol: TCP
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.redis.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.redis.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -102,11 +102,11 @@ config:
     # will compare total allocated bytes to this value. If allocation is too
     # high, cache capacity will be reduced and an error will be logged.
     # Useful values for this setting are generally in the range of 75%-90% of
-    # available system memory.
-    # This value should be set in according with the resources.limits.memory
+    # available system memory. Using 80% is the recommended.
+    # This value should be set in according to the resources.limits.memory
     # By default that setting is 2GB, and this is set to 85% of that limit
-    # 2 * 1024 * 1024 * 1024 * 0.85 = 1,825,361,101
-    MaxAlloc: 1825361101
+    # 2 * 1024 * 1024 * 1024 * 0.80 = 1,717,986,918
+    MaxAlloc: 1717986918
 
   # Logger describes which logger to use for Refinery logs. Valid options are
   # "logrus" and "honeycomb". The logrus option will write logs to STDOUT and the
@@ -201,11 +201,11 @@ redis:
   # To install a simple single pod Redis deployment set this to true.
   # If false, you must specify a value for existingHost
   # For production, it is recommended to set this to false and provide
-  # a highly available Redis configuration using existingHost
+  # a highly available Redis configuration using redis.existingHost
   enabled: true
 
   # If redis.enabled is false this needs to be specified.
-  # This needs to be the name:port of an Redis configuration
+  # This needs to be the name:port of a Redis configuration
   # existingHost:
 
   # If redis.enabled is true, this the image that will be used to create
@@ -215,6 +215,14 @@ redis:
     tag: 6.0.2
     pullPolicy: IfNotPresent
 
+  # Node selector specific to installed Redis configuration. Requires redis.enabled to be true
+  nodeSelector: {}
+
+  # Tolerations specific to installed Redis configuration. Requires redis.enabled to be true
+  tolerations: []
+
+  # Affinity specific to installed Redis configuration. Requires redis.enabled to be true
+  affinity: {}
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Adds support for all pod scheduling options specific to the Redis deployment. Adds the following parameters:
`redis.nodeSlector`
`redis.tolerations`
`redis.affinity`

Closes #56 

This PR also adds clarifying information that the default Redis install should not be used for highly available production architectures.

