### PR TITLE
Fix reference to `agent.watchers`

### DIFF
--- a/charts/honeycomb/README.md
+++ b/charts/honeycomb/README.md
@@ -24,7 +24,7 @@ helm install honeycomb honeycomb/honeycomb --set honeycomb.apiKey=YOUR_API_KEY
 ```
 
 ### Using modified log watchers configuration
-The agent watchers can be configured via this chart's `agent.watchers` property. Create a yaml file with your
+The agent watchers can be configured via this chart's `watchers` property. Create a yaml file with your
 Honeycomb API key and custom agent configuration similar to the following:
 ```yaml
 honeycomb:


### PR DESCRIPTION


## Which problem is this PR solving?

While reading the doc, I got confused about whether I should have a top-level `agent.watchers`. The last paragraph told me that `agent.` is no longer used, so this change seems correct.


## Short description of the changes

Change `agent.watchers` to `watchers`

