### PR TITLE
[refinery] update ingress support for k8s >= 1.19

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 1.1.2
-appVersion: 1.4.1
+version: 1.2.0
+appVersion: v1.5.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -184,8 +184,8 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.hosts[0].name` | Hostname to your Refinery installation | `refinery.local` |
-| `ingress.hosts[0].paths` | Path within the url structure | `[]` |
+| `ingress.hosts[0].host` | Hostname to use for Ingress | `refinery.local` |
+| `ingress.hosts[0].path` | Path prefix that will be used for the host | `/` |
 | `ingress.tls` | TLS hosts	| `[]` |
 | `resources` | CPU/Memory resource requests/limits | limit: 2000m/2Gi, request: 500m/500Mi |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
@@ -194,7 +194,11 @@ The following table lists the configurable parameters of the Refinery chart, and
 
 ## Upgrading
 
-### Upgrading from 1.1.1 or earlier.
+### Upgrading from 1.1.3 or earlier
+The ingress controller was refactored and support for multiple `paths` for every host was removed. Only a single `path` 
+can be specified for each ingress host.
+
+### Upgrading from 1.1.1 or earlier
 The default limits and replica count and memory were increased to properly represent minimum production requirements. 
 - `replicaCount` has been increased from `2` to `3`
 - `resources.limits.memory` has been increased from `1Gi` to `2Gi`

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -184,7 +184,7 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.hosts[0].host` | Hostname to use for Ingress | `refinery.local` |
+| `ingress.hosts[0].host` | Hostname to use for ingress | `refinery.local` |
 | `ingress.hosts[0].path` | Path prefix that will be used for the host | `/` |
 | `ingress.tls` | TLS hosts	| `[]` |
 | `resources` | CPU/Memory resource requests/limits | limit: 2000m/2Gi, request: 500m/500Mi |
@@ -193,10 +193,6 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `affinity` | Map of node/pod affinities | `{}` |
 
 ## Upgrading
-
-### Upgrading from 1.1.3 or earlier
-The ingress controller was refactored and support for multiple `paths` for every host was removed. Only a single `path` 
-can be specified for each ingress host.
 
 ### Upgrading from 1.1.1 or earlier
 The default limits and replica count and memory were increased to properly represent minimum production requirements. 

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -1,6 +1,11 @@
-{{- if and (.Values.ingress.enabled)  (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
+{{- if and (.Values.ingress.enabled)  (semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
 {{- $fullName := include "refinery.fullname" . -}}
-apiVersion: networking.k8s.io/v1
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -26,12 +31,9 @@ spec:
     - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{ .path | quote }}
-            pathType: Prefix
+          - path: {{ .path }}
             backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: data
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
     {{- end }}
 {{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -259,7 +259,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: refinery.local
-      paths: []
+      path: /
   tls: []
   #  - secretName: refinery-tls
   #    hosts:


### PR DESCRIPTION
## Which problem is this PR solving?

Starting with Kubernetes 1.19, the ingress controller was made stable. In Kubernetes >= 1.20 a warning will be displayed if the beta is used, with 1.22 marking when the beta is deprecated. 

This PR defines 2 ingresses that will be installed exclusively of each other. Depending on the version of the target Kubernetes (>=1.19, or <1.19) the stable or beta version of the ingress will be installed.

To keep the ingress simple, and avoid potential configuration confusion, support for multiple paths has also been removed. Frankly, it never worked before, so this is a low risk removal.

fixes #54 
