### PR TITLE
[secure-tenancy] update ingress support for k8s >= 1.19

### DIFF
--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: secure-tenancy
 description: Honeycomb Secure Tenancy
-version: 0.1.4
-appVersion: 1.9.1
+version: 1.0.0
+appVersion: 1.10.1
 keywords:
   - observability
   - security
@@ -17,5 +17,7 @@ icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
   - name: puckpuck
     email: pierre@honeycomb.io
-  - name: nathanleclaire
-    email: nathan@honeycomb.io
+  - name: kentquirk
+    email: kentquirk@honeycomb.io
+  - name: reulan
+    email: michaelsimo@honeycomb.io

--- a/charts/secure-tenancy/README.md
+++ b/charts/secure-tenancy/README.md
@@ -107,8 +107,8 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 | `service.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable ingress controller resource | `false` |
 | `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.hosts[0].name` | Hostname to your Secure Tenancy installation | `secure-tenancy.local` |
-| `ingress.hosts[0].paths` | Path within the url structure | `[]` |
+| `ingress.hosts[0].host` | Hostname to use for ingress | `secure-tenancy.local` |
+| `ingress.hosts[0].paths` | Array of path prefixes that will be used with the host | `[/]` |
 | `ingress.tls` | TLS hosts	| `[]` |
 | `autoscaling.enabled` | Enable autoscaling for Secure Tenancy deployment | `false` |
 | `autoscaling.minReplicas` | Minimum number of replicas to scale back (should be no less than 2) | `2` |
@@ -124,5 +124,13 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 ## Template Manifest
 It may be desired to have Helm render Kubernetes manifests but not have them installed.
 You can use the `helm template` command to accomplish this. 
-By default the output Kubernetes manifests will contain Helm specific annotations.
+By default, the output Kubernetes manifests will contain Helm specific annotations.
 You can remove these from the output templates by setting a special `omitHelm` parameter to false when generating the templates.
+
+## Upgrading
+
+### Upgrading from 0.1.4 or earlier 
+Support for stable Kubernetes was added. If you are deploying to a cluster that is Kubernetes version 1.19 or greater 
+this will leverage the stable version for Ingress. With the stable version, each path definition will use 
+`pathType: Prefix` which means the path itself can not contain any wildcards. If you previously had this set to `/*` or 
+similar, you will need to update your path to remove the wildcard.

--- a/charts/secure-tenancy/templates/ingress-beta.yaml
+++ b/charts/secure-tenancy/templates/ingress-beta.yaml
@@ -1,6 +1,11 @@
-{{- if and (.Values.ingress.enabled)  (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
+{{- if and (.Values.ingress.enabled)  (semverCompare "<1.19-0" .Capabilities.KubeVersion.GitVersion) -}}
 {{- $fullName := include "secure-tenancy.fullname" . -}}
-apiVersion: networking.k8s.io/v1
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -28,12 +33,9 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ . }}
-            pathType: Prefix
             backend:
-              service:
-                name: {{ $fullName }}
-                port:
-                  name: http
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
           {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Starting with Kubernetes 1.19, the ingress controller was made stable. In Kubernetes >= 1.20 a warning will be displayed if the beta is used, with 1.22 marking when the beta is deprecated.

This PR defines 2 ingresses that will be installed exclusively of each other. Depending on the version of the target Kubernetes (>=1.19, or <1.19) the stable or beta version of the ingress will be installed.

Also bumps version of secure-tenancy to 1.10.1
And finally updates the chart's version to 1.0.0 (long overdue).

fixes #55 