### PR TITLE
memory_limiter and default ports

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 0.4.3
-appVersion: 0.27.0
+version: 1.0.0
+appVersion: 0.36.0
 keywords:
   - observability
   - tracing

--- a/charts/opentelemetry-collector/README.md
+++ b/charts/opentelemetry-collector/README.md
@@ -119,7 +119,15 @@ The following table lists the configurable parameters of the Honeycomb chart, an
 
 ## Upgrading
 
-### Upgrading from 0.3.2 or earlier.
+### Upgrading from 0.4.3 or earlier
+OpenTelemetry has deprecated and removed the legacy ports for OTLP: 55680/55681. These ports have been removed from the 
+default configuration. The proper default ports for OTLP are 4317 for OTLP/GRPC and 4318 for OTLP/HTTP.
+
+Memory limiter and memory ballast have been reconfigured as part of the collector. A new processor and extension are now 
+used to configure memory limits and ballast. The default settings, will respond dynamically to the configured pod memory
+limits, and in most cases should not require any further configuration changes.
+
+### Upgrading from 0.3.2 or earlier
 The Honeycomb exporter has been deprecated in favor of using the OTLP exporter that the Honeycomb service supports natively. 
 Since the default OTLP exporter is now used, sampling of data on export is no longer supported, and use of the 
 `honeycomb.sample_rate` and `honeycomb.sample_rate_attribute` properties is no longer supported. 
@@ -129,7 +137,7 @@ Advanced sampling techniques can be accomplished using the [Honeycomb Refinery](
 The default value for the `honeycomb.apiHost` property has changed to represent a gRPC endpoint address. 
 If you copied this default value into your local values file, you will need to update this to `api.honeycomb.io:443` when upgrading.
 
-### Upgrading from 0.1.1 or earlier.
+### Upgrading from 0.1.1 or earlier
 A breaking change in the OTLP receiver configuration was introduced. This change is part of the default configuration. 
 If you changed the default OTLP receiver configuration, you will need to ensure your changes are compatible with the 
 updated configuration layout for OTLP.

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -41,13 +41,6 @@ spec:
           command:
             - "/otelcontribcol"
             - "--config=/conf/opentelemetry-collector-config.yaml"
-            {{- if .Values.config.processors }}
-            {{- if .Values.config.processors.memory_limiter }}
-            {{- if .Values.config.processors.memory_limiter.ballast_size_mib }}
-            - "--mem-ballast-size-mib={{ .Values.config.processors.memory_limiter.ballast_size_mib }}"          
-            {{- end }}
-            {{- end }}
-            {{- end }}
           env:
             - name: HONEYCOMB_API_KEY
               valueFrom:
@@ -68,15 +61,17 @@ spec:
             {{- end }}
           volumeMounts:
             - name: opentelemetry-collector-config
-              mountPath: /conf          
+              mountPath: /conf
+          {{- if .Values.config.extensions.health_check }}
           livenessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: {{ .Values.config.extensions.health_check.port }}
           readinessProbe:
             httpGet:
               path: /
-              port: 13133
+              port: {{ .Values.config.extensions.health_check.port }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/opentelemetry-collector/values.yaml
+++ b/charts/opentelemetry-collector/values.yaml
@@ -12,22 +12,18 @@ honeycomb:
 
   # Specify the name of an existing secret resource containing your Honeycomb API KEY instead of having a secret resource created
   # existingSecret:
-  # Use this to specify options for the OTLP exporter, such as insecure, or balancer_name.
+
+  # Use this to specify options for the OTLP/GRPC exporter, such as insecure, or balancer_name.
   # All export options except for endpoint, and headers can be specified.
   # exportOptions:
   #   insecure: true
   #   balancer_name: round_robin
 
-  # Use this to specify options for the OTLP exporter, such as insecure, or balancer_name.
-  # All export options except for endpoint, and headers can be specified.
-  # exportOptions:
-  #   insecure: true
-  #   balancer_name: round_robin
-
+  # DEPRECATED: Use of this option is deprecated and will be removed in a future release
   # Use this option to use the old Honeycomb Exporter instead of OTLP (default is false)
   # When set to true:
   #   - the honeycomb.apiHost property needs to be changed to a URL with an http/https scheme.
-  #   - the config.service.pipelines.traces.exporters property needs to be changed to specify the honeycomb exporter instead of otlp
+  #   - the config.service.pipelines.traces.exporters property needs to be changed to specify the honeycomb exporter instead of OTLP
   # useHoneycombExporter: false
 
 
@@ -48,16 +44,13 @@ config:
   processors:
     batch:
     memory_limiter:
-      # memory ballast size should be max 1/3 to 1/2 of pod memory limits
-      ballast_size_mib: 683
-      # 80% of maximum memory up to 2G
-      limit_mib: 400
-      # 25% of limit up to 2G
-      spike_limit_mib: 100
-      # How often to check for memory limits      
       check_interval: 5s
+      limit_percentage: 75
+      spike_limit_percentage: 25
       
   extensions:
+    memory_ballast:
+      size_in_percentage: 35
     health_check:
       port: 13133
 
@@ -102,40 +95,35 @@ service:
   annotations: {}
 
 ports: # configures both service, and deployment
-  otlp:
+  otlp-grpc:
     enabled: true
-    containerPort: 55680 # "legacy" port for backwards compatibility
-    servicePort: 55680
+    containerPort: 4317
+    servicePort: 4317
     protocol: TCP
   otlp-http:
     enabled: true
-    containerPort: 55681 # http server starts up on 55681
-    servicePort: 55681
+    containerPort: 4318
+    servicePort: 4318
     protocol: TCP
-  otlp-grpc:
-    enabled: true
-    containerPort: 4317 # new service port
-    servicePort: 4317
-    protocol: TCP
-  jaeger-http:
-    enabled: true
-    containerPort: 14268
-    servicePort: 14268
-    protocol: TCP
-  jaeger-binary:
-    enabled: true
-    containerPort: 6832
-    servicePort: 6832
-    protocol: UDP
   jaeger-compact:
     enabled: true
     containerPort: 6831
     servicePort: 6831
     protocol: UDP
+  jaeger-binary:
+    enabled: true
+    containerPort: 6832
+    servicePort: 6832
+    protocol: UDP
   jaeger-grpc:
     enabled: true
     containerPort: 14250
     servicePort: 14250
+    protocol: TCP
+  jaeger-http:
+    enabled: true
+    containerPort: 14268
+    servicePort: 14268
     protocol: TCP
   zipkin:
     enabled: true


### PR DESCRIPTION
## Which problem is this PR solving?

Update to the latest version of Otel collector (0.36.0)  which has full stability for tracing. This version does introduce 2 changes from the prior release: OTLP legacy ports deprecated, memory_limiter changes.

The OTLP legacy port changes are potentially breaking to other installations. This change, enforced by the collector itself in [this change](https://github.com/open-telemetry/opentelemetry-collector/pull/3966) may break existing SDKs that are sending data on the legacy ports.

The memory limiter changes are meant to make it easier to configure and in most cases config-less for memory consumption settings. These are also enforced by changes in the collector itself.

With the stability of tracing within the collector, it makes sense to make this a version 1.0.0 release.