### PR TITLE
[refinery] add HPA support

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 1.2.0
-appVersion: v1.5.0
+version: 1.3.0
+appVersion: v1.5.2
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -114,6 +114,15 @@ Refer to the comments in [values.yaml](./values.yaml) for more details about eac
 See [Refinery: Scale and Troubleshoot](https://docs.honeycomb.io/manage-data-volume/refinery/scale-and-troubleshoot/)
 for more details on how to properly scale Refinery.
 
+### Using Autoscaling
+
+Refinery can be configured to auto-scale with load. During auto-scale events, trace sharding is recomputed, which will
+result in traces with missing spans being sent to Honeycomb. Traces with missing spans can happen for upto the 
+`config.TraceTimeout * 2`. In order to avoid auto-scale events, it is recommended to disable scaleDown which will limit
+broken traces should traffic rapidly go up and down.
+
+Autoscaling of refinery is configured using the `autoscaling` setting.
+
 ## Redis Configuration
 
 By default, a single node configuration of Redis will be installed. This configuration **is not** recommended for 
@@ -192,6 +201,12 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `ingress.hosts[0].path` | Path prefix that will be used for the host | `/` |
 | `ingress.tls` | TLS hosts	| `[]` |
 | `resources` | CPU/Memory resource requests/limits | limit: 2000m/2Gi, request: 500m/500Mi |
+| `autoscaling.enabled` | Enabled autoscaling for Refinery | `false` |
+| `autoscaling.minReplicas` | Set minimum number of replicas for Refinery | `3` |
+| `autoscaling.maxReplicas` | Set maximum number of replicas for Refinery | `10` |
+| `autoscaling.targetCPUUtilizationPercentage` | Set the target CPU utilization percentage for scaling | `75` | 
+| `autoscaling.targetMemoryUtilizationPercentage` | Set the target Memory utilization percentage for scaling | `nil` |
+| `autoscaling.behavior` | Set the autoscaling behavior | scaleDown.selectPolicy: disabled |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Tolerations for pod assignment | `[]`|
 | `affinity` | Map of node/pod affinities | `{}` |

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
   {{- include "refinery.selectorLabels" . | nindent 6 }}

--- a/charts/refinery/templates/hpa.yaml
+++ b/charts/refinery/templates/hpa.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "refinery.fullname" . }}
+  labels:
+    {{- include "refinery.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "refinery.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  behavior:
+  {{- toYaml .Values.autoscaling.behavior | nindent 4 }}
+{{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -7,11 +7,14 @@
 # decisions and dropped traces. As such, we recommend provisioning refinery for
 # your anticipated peak load
 #
+
 # Use replicaCount and resource limits to set the size of your Refinery cluster
 # per your anticipated peak load.
+# replicaCount is ignored if autoscaling is enabled
+replicaCount: 3
+
 # Changing memory limits from the default 2Gi, requires updates to the
 # config.InMemCollector.MaxAlloc property.
-replicaCount: 3
 resources:
   limits:
     cpu: 2000m
@@ -269,6 +272,21 @@ ingress:
   #  - secretName: refinery-tls
   #    hosts:
   #      - refinery.local
+
+# Setup autoscaling for refinery
+# When autoscaling events occur, trace sharding will be recomputed. This will result in traces with missing spans being
+# sent to Honeycomb, for a small period of time (approximately config.TraceTimeout * 2).
+# Because of this, scaleDown is disabled by default to avoid unnecessary broken traces should traffic go up and down rapidly.
+autoscaling:
+  enabled: false
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+  # targetMemoryUtilizationPercentage: 80
+  behavior:
+    scaleDown:
+      selectPolicy: Disabled
+
 
 nodeSelector: {}
 


### PR DESCRIPTION
## Which problem is this PR solving?

Adds support for dynamic autoscaling using an HPA. The default autoscaling configuration is to disable scaledown, as scaling events can cause traces with missing spans.  The documentation explains this.

