### PR TITLE
[refinery] Force pods to recycle on rules changes

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap-config.yaml") . | sha256sum }}
+        checksum/rules: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
### Summary
Pods are not recycled when making changes to refinery sampling rules to a deployed cluster using `helm upgrade`. Refinery live-reloads changes to rules.yaml and does not strictly need a restart for the changes to be applied.

Changes to config.yaml doe result in pods being recycled.

However, this make it look like changes have not been applied to the cluster when looking at cluster health. This change adds a new pod annotation for the rules.yaml which ensures pods are recycled when rules.yaml are changed.

- Closes #83 

### Changes
- Add new pod annotation that uses the checksum of rules.yaml