### PR TITLE
[refinery] Upgrade Refinery to v1.8.0, for configurable MaxBatchSize

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.3.1
-appVersion: 1.6.1
+appVersion: 1.8.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -223,6 +223,10 @@ The following table lists the configurable parameters of the Refinery chart, and
 
 ## Upgrading
 
+### Upgrading from 1.3.1 or earlier
+
+`MaxBatchSize` is now configurable, set by default to its initially hardcoded value of 500. This value represents the number of events to include in a batch to be sent.
+
 ### Upgrading from 1.2.0 or earlier
 `PeerManagement` defaults are being set, including `NetworkIdentifierName: eth0`. This was necessary
 to ensure communications when DNS on K8s can be flaky at times (especially on startup). If you had set this before

--- a/charts/refinery/sample-configs/config_complete.yaml
+++ b/charts/refinery/sample-configs/config_complete.yaml
@@ -64,6 +64,9 @@ SendDelay: 2s
 # Eligible for live reload.
 TraceTimeout: 60s
 
+# MaxBatchSize is the number of events to be included in the batch for sending
+MaxBatchSize: 500
+
 # SendTicker is a short timer; it determines the duration to use to check for traces to send
 SendTicker: 100ms
 

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -80,6 +80,9 @@ config:
   # timer. This supports duration strings with supplied units.
   TraceTimeout: 60s
 
+  # MaxBatchSize is the number of events to be included in the batch for sending
+  MaxBatchSize: 500
+
   # SendTicker is a short timer; it determines the duration to use to check for traces to send
   SendTicker: 100ms
 


### PR DESCRIPTION
Upgrade Refinery Helm Chart to [v1.8.0](https://github.com/honeycombio/refinery/releases/tag/v1.8.0)

This new version adds a configurable option for MaxBatchSize, with a set default of 500 (previous hardcoded default)