### PR TITLE
[k8s] Prep honeycomb kubernetes agent helm chart release v1.1.1

### DIFF
--- a/charts/honeycomb/CHANGELOG.md
+++ b/charts/honeycomb/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Honeycomb Kubernetes Agent Helm Chart Changelog
 
+## Honeycomb Kubernetes Agent v1.1.1
+
+- Fixes selectors for container metadata and logs
+
 ## Honeycomb Kubernetes Agent v1.1.0
 
 - Adds support for multiple architectures (amd64 + arm64) #64

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.1.0
-appVersion: 2.2.0
+version: 1.1.1
+appVersion: 2.2.1
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
Prep honeycomb kubernetes agent helm chart release v1.1.1

- Changelog updated for v1.1.1 for fixes made in kubernetes agent
- Chart versions updated for chart v1.1.1 and kubernetes agent v2.2.1