### PR TITLE
agent: prepare release 1.2.0

### DIFF
--- a/charts/honeycomb/CHANGELOG.md
+++ b/charts/honeycomb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb Kubernetes Agent Helm Chart Changelog
 
+## Honeycomb Kubernetes Agent v1.2.0
+
+- Adds node metadata to metrics events
+- Fixes intermittent exception in metrics processor
+
 ## Honeycomb Kubernetes Agent v1.1.1
 
 - Fixes selectors for container metadata and logs

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.1.1
-appVersion: 2.2.1
+version: 1.2.0
+appVersion: 2.3.0
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
chart for agent release [2.3.0](https://github.com/honeycombio/honeycomb-kubernetes-agent/releases/tag/v2.3.0)