### PR TITLE
[Refinery] Introduce optional init container for Refinery deployment to ensure Redis connectivity

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -220,6 +220,8 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Tolerations for pod assignment | `[]`|
 | `affinity` | Map of node/pod affinities | `{}` |
+| `initContainer.enabled` | When true, an init container will be added in Refinery deployment to wait until Redis instances are reachable | `false` |
+| `initContainer.redisHost` | Custom redis host name used by Refinery init container to test connectivity | `nil` |
 
 ## Upgrading
 

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -35,6 +35,18 @@ spec:
       serviceAccountName: {{ include "refinery.serviceAccountName" . }}
       securityContext:
       {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainer.enabled }}
+      initContainers:
+        - name: init-redis
+          image: busybox
+          command:
+            [
+              {{- $redisHost := ternary (printf "%s.%s.svc.cluster.local" (include "refinery.redis.fullname" .) .Release.Namespace) .Values.initContainer.redisHost .Values.redis.enabled -}}
+              "sh",
+              "-c",
+              "until nc -z {{ $redisHost }} 6379; do echo waiting for {{ $redisHost }} 6379; sleep 1; done",
+            ]
+      {{- end }}            
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -34,6 +34,13 @@ imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""
 
+# Use to configure an init container for Refinery deployment to wait until
+# the redis host is reachable
+initContainer:
+  enabled: true
+  # A custom redis host should be specified if using an external redis installation
+  # redisHost: ""
+
 # Use to pass in additional environment variables into Refinery
 # Refinery supports environment variables for some configuration options such as:
 # - Honeycomb API Key used by Logger and Metrics: REFINERY_HONEYCOMB_API_KEY


### PR DESCRIPTION
### Which problem is this PR solving?
Refinery pods crash looping until Redis instances are healthy. 

### Short description of the changes
This PR adds an optional init container for Refinery deployment to sleep until Redis instances are up and running. 
No breaking changes.
