### PR TITLE
add nodes resource to honeycomb/templates/cluster-role

### DIFF
--- a/charts/honeycomb/templates/cluster-role.yaml
+++ b/charts/honeycomb/templates/cluster-role.yaml
@@ -14,6 +14,9 @@ rules:
       - pods
       - nodes/stats
       - nodes/proxy
+      {{- if .Values.metrics.includeNodeLabels }}
+      - nodes
+      {{- end }}
     verbs:
       - get
       - list


### PR DESCRIPTION
In https://github.com/honeycombio/honeycomb-kubernetes-agent/pull/200 we added the option to add node metadata labels to metric events in the honeycomb-kubernetes-agent. In order to list nodes, the ClusterRole requires access to the nodes resource. We'll only include this resource if the `includeNodeLabels` config value is true. 