### PR TITLE
[honeycomb] bump agent version to 2.3.1

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
 version: 1.2.0
-appVersion: 2.3.0
+appVersion: 2.3.1
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
* fixes nil pointer deref when includeNodeLabels is enabled