### PR TITLE
Update ST chart to support 1.12.1

### DIFF
--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: secure-tenancy
 description: Honeycomb Secure Tenancy
 version: 1.0.0
-appVersion: 1.10.1
+appVersion: 1.12.1
 keywords:
   - observability
   - security

--- a/charts/secure-tenancy/README.md
+++ b/charts/secure-tenancy/README.md
@@ -1,6 +1,6 @@
 # Honeycomb Secure Tenancy Proxy
 
-[Honeycomb](https://honeycomb.io) is built for modern dev teams to see and understand how their production systems are 
+[Honeycomb](https://honeycomb.io) is built for modern dev teams to see and understand how their production systems are
 behaving. Our goal is to give engineers the observability they need to eliminate toil and delight their users.
 This helm chart will install the [Honeycomb Secure Tenancy Proxy](https://docs.honeycomb.io/authentication-and-security/secure-tenancy/).
 
@@ -23,7 +23,7 @@ docker push YOUR_REPOSITORY/honeycomb/secure-tenancy
 ### Simple install (recommended for testing)
 This will install the Secure Tenancy proxy, and a MySQL database using the Bitnami MariaDB chart.
 A job to migrate and initialize the database will also be run as a post-install hook.
-Since the job requires the MySQL database to be up and running, the Helm install command below may not return for upto 
+Since the job requires the MySQL database to be up and running, the Helm install command below may not return for up to
 3 minutes.
 ```bash
 helm repo add honeycomb https://honeycombio.github.io/helm-charts
@@ -33,8 +33,8 @@ helm install secure-tenancy honeycomb/secure-tenancy \
 ```
 
 ### Advanced install (recommended for production)
-It's recommended to use a Helm values file to install this chart. The `honeycomb.authToken` and `image.repository` parameters are required. 
-When used in a production environment a MySQL database is typically provided. 
+It's recommended to use a Helm values file to install this chart. The `honeycomb.authToken` and `image.repository` parameters are required.
+When used in a production environment a MySQL database is typically provided.
 You will need to set `mysql.enabled` to false, and `mysql.existingHost` to the host and port of the provided database.
 All parameters, including those used for database credentials are described in the [Parameters](#parameters) section.
 A typical installation values file may look like the following:
@@ -71,66 +71,67 @@ helm install secure-tenancy honeycomb/secure-tenancy --values my-values.yaml
 
 The following table lists the configurable parameters of the Honeycomb chart, and their default values.
 
-| Parameter | Description | Default |
-| --- | --- | --- |
-| `honeycomb.authToken` | Honeycomb Secure Tenancy authorization token | `YOUR_AUTH_TOKEN` |
-| `honeycomb.apiHost` | API URL to sent events to | `https://api.honeycomb.io` |
-| `honeycomb.grpcApiHost` | API URL for OTLP over gRPC to sent events to. Must include port. | `https://api.honeycomb.io:443` |
-| `honeycomb.uiBaseUrl` | URL used to access Honeycomb UI | `https://ui.honeycomb.io` |
-| `honeycomb.maxIdleConnsPerHost` | Maximum # of Idle connections to MySQL database | `100` |
-| `honeycomb.hsts.enabled` | Wether or not to enable HTTP Strict Transport Security | `false` |
-| `honeycomb.hsts.maxAge` | When HTST is enabled this is the max age in seconds | `31536000` |
-| `honeycomb.transformer` | The Transformer to use for Secure Tenancy. Must be `aes256siv` or `sha256hmac` | `aes256siv` |
-| `nameOverride` | String to partially override honeycomb.fullname template with a string (will append the release name) | `nil` |
-| `fullnameOverride` | String to fully override honeycomb.fullname template with a string | `nil` |
-| `imagePullSecrets` | Specify docker-registry secret names as an array | `[]` |
-| `image.repository` | Honeycomb Secure Tenancy proxy repository and image name | `nil` |
-| `image.tag` | Image tag to use (leave blank for latest) | `nil` |
-| `image.pullPolicy` | Honeycomb agent image pull policy | `IfNotPresent` |
-| `replicaCount` | Number of Secure Tenancy proxy server replicas to run | `2` |
-| `metrics.apiKey` | Honeycomb API Key for Team to receive metrics about Secure Tenancy proxy | `YOUR_API_KEY` |
-| `metrics.dataset` | Name of dataset to sent metrics to | `secure-tenancy` |
-| `metrics.apiHost` | API URL to sent metrics to | `https://api.honeycomb.io` |
-| `mysql.enabled` | When true the Bitnami MariaDB chart will be installed. | `true` |
-| `mysql.existingHost` | If `mysql.enabled` is false, this must be set to the name and port of an existing MySQL database | `nil` |
-| `mysql.tls` | Use TLS when communicating with MySQL | `false` |
-| `mysql.maxopenconns` | Maximum open connections to MySQL | `100` |
-| `mysql.db.user` | Name of MySQL user to connect as | `hny-secure-tenancy` |
-| `mysql.db.password` | Password for database user | `db_password` |
-| `mysql.db.name` | Name of MySQL database to connect | `hny-secure-tenancy` |
-| `mysql.rootUser.password` | When `mysql.enabled` is true this will be the root password used | `root_password` |
-| `mysql.replication.password` | When `mysql.enabled` is true this will be the replication password used | `replication_password` |
-| `service.type` | Kubernetes Service type | `ClusterIP` |
-| `service.port` | Service port for Honeycomb formatted telemetry | `80` |
-| `service.grpcPort` | Service port for OTLP over gRPC telemetry | `4317` |
-| `service.ip` | LoadBalancer service IP address | `nil` |
-| `service.annotations` | Service annotations | `{}` |
-| `ingress.enabled` | Enable ingress controller resource | `false` |
-| `ingress.annotations` | Ingress annotations | `{}` |
-| `ingress.hosts[0].host` | Hostname to use for ingress | `secure-tenancy.local` |
-| `ingress.hosts[0].paths` | Array of path prefixes that will be used with the host | `[/]` |
-| `ingress.tls` | TLS hosts	| `[]` |
-| `autoscaling.enabled` | Enable autoscaling for Secure Tenancy deployment | `false` |
-| `autoscaling.minReplicas` | Minimum number of replicas to scale back (should be no less than 2) | `2` |
-| `autoscaling.maxReplicas` | Maximum number of replicas to scale out | `100` |
-| `autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization percentage | `80` |
-| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage | `80` |
-| `podAnnotations` | Pod annotations | `{}` |
-| `resources` | CPU/Memory resource requests/limits | `{}` | 
-| `nodeSelector` | Node labels for pod assignment | `{}` | 
-| `tolerations` | Tolerations for pod assignment | `[]`| 
-| `affinity` | Map of node/pod affinities | `{}` |
+| Parameter                                       | Description                                                                                           | Default                        |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------ |
+| `honeycomb.authToken`                           | Honeycomb Secure Tenancy authorization token                                                          | `YOUR_AUTH_TOKEN`              |
+| `honeycomb.apiHost`                             | API URL to sent events to                                                                             | `https://api.honeycomb.io`     |
+| `honeycomb.grpcApiHost`                         | API URL for OTLP over gRPC to sent events to. Must include port.                                      | `https://api.honeycomb.io:443` |
+| `honeycomb.uiBaseUrl`                           | URL used to access Honeycomb UI                                                                       | `https://ui.honeycomb.io`      |
+| `honeycomb.maxIdleConnsPerHost`                 | Maximum # of Idle connections to MySQL database                                                       | `100`                          |
+| `honeycomb.hsts.enabled`                        | Wether or not to enable HTTP Strict Transport Security                                                | `false`                        |
+| `honeycomb.hsts.maxAge`                         | When HTST is enabled this is the max age in seconds                                                   | `31536000`                     |
+| `honeycomb.transformer`                         | The Transformer to use for Secure Tenancy. Must be `aes256siv` or `sha256hmac`                        | `aes256siv`                    |
+| `honeycomb.maxParallelism`                      | Maximum number of parallel routines to process encryption                                             | `8`                            |
+| `nameOverride`                                  | String to partially override honeycomb.fullname template with a string (will append the release name) | `nil`                          |
+| `fullnameOverride`                              | String to fully override honeycomb.fullname template with a string                                    | `nil`                          |
+| `imagePullSecrets`                              | Specify docker-registry secret names as an array                                                      | `[]`                           |
+| `image.repository`                              | Honeycomb Secure Tenancy proxy repository and image name                                              | `nil`                          |
+| `image.tag`                                     | Image tag to use (leave blank for latest)                                                             | `nil`                          |
+| `image.pullPolicy`                              | Honeycomb agent image pull policy                                                                     | `IfNotPresent`                 |
+| `replicaCount`                                  | Number of Secure Tenancy proxy server replicas to run                                                 | `2`                            |
+| `metrics.apiKey`                                | Honeycomb API Key for Team to receive metrics about Secure Tenancy proxy                              | `YOUR_API_KEY`                 |
+| `metrics.dataset`                               | Name of dataset to sent metrics to                                                                    | `secure-tenancy`               |
+| `metrics.apiHost`                               | API URL to sent metrics to                                                                            | `https://api.honeycomb.io`     |
+| `mysql.enabled`                                 | When true the Bitnami MariaDB chart will be installed.                                                | `true`                         |
+| `mysql.existingHost`                            | If `mysql.enabled` is false, this must be set to the name and port of an existing MySQL database      | `nil`                          |
+| `mysql.tls`                                     | Use TLS when communicating with MySQL                                                                 | `false`                        |
+| `mysql.maxopenconns`                            | Maximum open connections to MySQL                                                                     | `100`                          |
+| `mysql.db.user`                                 | Name of MySQL user to connect as                                                                      | `hny-secure-tenancy`           |
+| `mysql.db.password`                             | Password for database user                                                                            | `db_password`                  |
+| `mysql.db.name`                                 | Name of MySQL database to connect                                                                     | `hny-secure-tenancy`           |
+| `mysql.rootUser.password`                       | When `mysql.enabled` is true this will be the root password used                                      | `root_password`                |
+| `mysql.replication.password`                    | When `mysql.enabled` is true this will be the replication password used                               | `replication_password`         |
+| `service.type`                                  | Kubernetes Service type                                                                               | `ClusterIP`                    |
+| `service.port`                                  | Service port for Honeycomb formatted telemetry                                                        | `80`                           |
+| `service.grpcPort`                              | Service port for OTLP over gRPC telemetry                                                             | `4317`                         |
+| `service.ip`                                    | LoadBalancer service IP address                                                                       | `nil`                          |
+| `service.annotations`                           | Service annotations                                                                                   | `{}`                           |
+| `ingress.enabled`                               | Enable ingress controller resource                                                                    | `false`                        |
+| `ingress.annotations`                           | Ingress annotations                                                                                   | `{}`                           |
+| `ingress.hosts[0].host`                         | Hostname to use for ingress                                                                           | `secure-tenancy.local`         |
+| `ingress.hosts[0].paths`                        | Array of path prefixes that will be used with the host                                                | `[/]`                          |
+| `ingress.tls`                                   | TLS hosts                                                                                             | `[]`                           |
+| `autoscaling.enabled`                           | Enable autoscaling for Secure Tenancy deployment                                                      | `false`                        |
+| `autoscaling.minReplicas`                       | Minimum number of replicas to scale back (should be no less than 2)                                   | `2`                            |
+| `autoscaling.maxReplicas`                       | Maximum number of replicas to scale out                                                               | `100`                          |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                                     | `80`                           |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                                  | `80`                           |
+| `podAnnotations`                                | Pod annotations                                                                                       | `{}`                           |
+| `resources`                                     | CPU/Memory resource requests/limits                                                                   | `{}`                           |
+| `nodeSelector`                                  | Node labels for pod assignment                                                                        | `{}`                           |
+| `tolerations`                                   | Tolerations for pod assignment                                                                        | `[]`                           |
+| `affinity`                                      | Map of node/pod affinities                                                                            | `{}`                           |
 
 ## Template Manifest
 It may be desired to have Helm render Kubernetes manifests but not have them installed.
-You can use the `helm template` command to accomplish this. 
+You can use the `helm template` command to accomplish this.
 By default, the output Kubernetes manifests will contain Helm specific annotations.
 You can remove these from the output templates by setting a special `omitHelm` parameter to false when generating the templates.
 
 ## Upgrading
 
-### Upgrading from 0.1.4 or earlier 
-Support for stable Kubernetes was added. If you are deploying to a cluster that is Kubernetes version 1.19 or greater 
-this will leverage the stable version for Ingress. With the stable version, each path definition will use 
-`pathType: Prefix` which means the path itself can not contain any wildcards. If you previously had this set to `/*` or 
+### Upgrading from 0.1.4 or earlier
+Support for stable Kubernetes was added. If you are deploying to a cluster that is Kubernetes version 1.19 or greater
+this will leverage the stable version for Ingress. With the stable version, each path definition will use
+`pathType: Prefix` which means the path itself can not contain any wildcards. If you previously had this set to `/*` or
 similar, you will need to update your path to remove the wildcard.

--- a/charts/secure-tenancy/templates/configmap.yaml
+++ b/charts/secure-tenancy/templates/configmap.yaml
@@ -15,6 +15,7 @@ data:
     max_idle_conns_per_host: {{ .Values.honeycomb.maxIdleConnsPerHost }}
     grpc_listen_addr: 8081
     api_grpc_base_url: {{ .Values.honeycomb.grpcApiHost | quote }}
+    max_parallelism: {{ .Values.honeycomb.maxParallelism }}
   mysqlconfig.yaml: |
     host: "{{ include "db.fullhost" . }}"
     database: {{ .Values.mysql.db.name | quote }}

--- a/charts/secure-tenancy/values.yaml
+++ b/charts/secure-tenancy/values.yaml
@@ -7,7 +7,7 @@ honeycomb:
   grpcApiHost: https://api.honeycomb.io:443
 
   uiBaseUrl: https://ui.honeycomb.io
-  
+
   maxIdleConnsPerHost: 100
   hsts:
     enabled: false
@@ -15,11 +15,15 @@ honeycomb:
 
   # Transformer to use.  Valid values are `aes256siv` or `sha256hmac`
   transformer: aes256siv
-  
+  # maximum number of goroutines to process encryption requests.
+  # See documentation on tuning this value at
+  # https://docs.honeycomb.io/authentication-and-security/secure-tenancy/deployments/#tuning-the-secure-proxy
+  maxParallelism: 8
+
 
 image:
   # this must be provided
-  repository: 
+  repository:
   tag:
   pullPolicy: IfNotPresent
 
@@ -27,9 +31,10 @@ image:
 replicaCount: 2
 
 
-# Secure Tenancy self-metrics.
+# Secure Tenancy telemetry (recommended)
+# see https://docs.honeycomb.io/authentication-and-security/secure-tenancy/configuration/#send-proxy-metrics-to-honeycomb
 metrics:
-  # leave API key blank to disable self-metrics
+  # leave API key blank to disable telemetry
   apiKey:
   dataset: secure-tenancy
   apiHost: https://api.honeycomb.io
@@ -42,7 +47,7 @@ mysql:
   # if mysql.enabled is false this needs to be specified when the name of the host
   # when specified mysql will not be installed and the specified host:port will be used instead
   # this takes not effect if mysql.enabled is true
-  # existingHost: 
+  # existingHost:
 
   # Use TLS when communicating with MySQL
   tls: false
@@ -56,7 +61,7 @@ mysql:
     password: db_password
     # MySQL database
     name: hny-secure-tenancy
-  
+
   # if mysql.enabled is true, ths is the root password used
   rootUser:
     password: root_password
@@ -64,11 +69,11 @@ mysql:
   replication:
     password: replication_password
 
-  # disable tests by default 
+  # disable tests by default
   tests:
     enabled: false
 
-       
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
@@ -79,7 +84,7 @@ service:
   port: 80
   grpcPort: 4317
   # If using a LoadBalancer service, you may also want to specify the IP to use
-  # ip: 
+  # ip:
 
 ingress:
   enabled: false
@@ -109,11 +114,11 @@ resources: {}
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  #   cpu: 2
+  #   memory: 2Gi
   # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  #   cpu: 2
+  #   memory: 2Gi
 
 nodeSelector: {}
 


### PR DESCRIPTION
This updates the Secure Tenancy chart to support Release 1.12.1 of Secure Tenancy, including adding support for the new max_parallelism configuration value. A few edits were also made to documentation and readme.

The editor also brought the edited files up to markdown formatting standards, so there are also a bunch of whitespace changes; use github's "ignore whitespace" feature to trim this down to the minimum diffs if necessary.

Closes #102
