### PR TITLE
Allow operators to disable live reload of Refinery related to changed sampling rules

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -110,7 +110,7 @@ This can be accomplished by setting
 ```yaml
 rules:
   LiveReload:
-    disabled: true
+    enabled: false
 ```
 
 ## Scaling Refinery

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -109,8 +109,7 @@ This can be accomplished by setting
 
 ```yaml
 rules:
-  LiveReload:
-    enabled: false
+  LiveReload: false
 ```
 
 ## Scaling Refinery

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -98,6 +98,21 @@ rules:
     AdjustmentInterval: 15
     Weight: 0.5
 ```
+
+### Disabling Live-Reload on Rules Changes
+
+Depending on Kubernetes use-cases, operators may wish to disable Refinery's
+default live-reload behavior on rules changes and rely instead on Kubernetes
+to trigger a rolling pod update when the rule configmap changes.
+
+This can be accomplished by setting
+
+```yaml
+rules:
+  LiveReload:
+    disabled: true
+```
+
 ## Scaling Refinery
 
 Refinery is a stateful service and is not optimized for dynamic auto-scaling. Changes in cluster membership can result

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         {{- end }}
+        {{- if .Values.rules.LiveReload.disabled }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
+        {{- end }}
       labels:
       {{- include "refinery.selectorLabels" . | nindent 8 }}
       {{- with .Values.podLabels }}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         {{- end }}
-        {{- if not .Values.rules.LiveReload.enabled }}
+        {{- if hasKey .Values.rules "LiveReload" | ternary (not .Values.rules.LiveReload) false }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- end }}
       labels:

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         {{- end }}
-        {{- if .Values.rules.LiveReload.disabled }}
+        {{- if not .Values.rules.LiveReload.enabled }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- end }}
       labels:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -233,8 +233,8 @@ rules:
 
   # LiveReload - If disabled, triggers a rolling restart of the cluster whenever the Rules
   # configmap changes
-  # LiveReload:
-  #   disabled: true
+  LiveReload:
+    enabled: true
 
 # Redis configuration
 redis:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -231,10 +231,9 @@ rules:
     #  - request.method
     #  - response.status_code
 
-  # LiveReload - If disabled, triggers a rolling restart of the cluster whenever the Rules
-  # configmap changes
-  LiveReload:
-    enabled: true
+  # LiveReload - If disabled, triggers a rolling restart of the cluster whenever
+  # the Rules configmap changes
+  LiveReload: true
 
 # Redis configuration
 redis:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -231,6 +231,10 @@ rules:
     #  - request.method
     #  - response.status_code
 
+  # LiveReload - If disabled, triggers a rolling restart of the cluster whenever the Rules
+  # configmap changes
+  # LiveReload:
+  #   disabled: true
 
 # Redis configuration
 redis:


### PR DESCRIPTION
This PR is a workaround for the issue describe in #101