### PR TITLE
[opentelemetry-collector] - update to collector 0.43.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 1.0.0
-appVersion: 0.36.0
+version: 1.0.1
+appVersion: 0.43.0
 keywords:
   - observability
   - tracing

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -38,8 +38,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - "/otelcontribcol"
+          args:
             - "--config=/conf/opentelemetry-collector-config.yaml"
           env:
             - name: HONEYCOMB_API_KEY


### PR DESCRIPTION
Updates to the latest version of the OpenTelemetry collector (0.43.0)

Because of a change in executable, and we should be following best practices here anyhow, this also removes the `command` property, and instead just uses `args`, which will allow the base image to define the entrypoint.