### PR TITLE
Prepare otel collector chart v1.1.0 release

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenTelemetry Collector Helm Chart Changelog
 
+## OpenTelemetry Collector v1.1.0
+
+- Update OpenTelemetry Collector to v0.43.0 (#106)
+
 ## OpenTelemetry Collector v1.0.0
 
 ### Breaking Changes

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 1.0.1
+version: 1.1.0
 appVersion: 0.43.0
 keywords:
   - observability


### PR DESCRIPTION
### Description
Prepares the v1.1.0 release of the OpenTelemtry Collector chart.

### Changes
- Adds changelog entry
- Updates chart version to 1.1.0