### PR TITLE
Remove secure-tenancy chart owner override

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For anything not explicitly taken by someone else:
 * @honeycombio/telemetry-team
 
-/charts/secure-tenancy/ @honeycombio/secure-tenancy
+* /charts/secure-tenancy/ @honeycombio/secure-tenancy


### PR DESCRIPTION
For now the @honeycombio/telemetry-team are managing all charts, including the Secure-Tenancy one. This PR removes the team override for now so we can approve and merge PRs.