### PR TITLE
[refinery] add new headless service for gRPC clients

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -212,6 +212,10 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `service.grpcPort` | Service port for data in OTLP format over gRPC | `4317` |
 | `service.labels` | Service labels | `{}` |
 | `service.annotations` | Service annotations | `{}` |
+| `headlessService.enabaled` | Enable Kubernetes Headless Service for gRPC traffic | `false` |
+| `headlessService.grpcPort` | Headless Service port for data in OTLP format over gRPC | `4317` |
+| `headlessService.labels` | Hedless Service labels | `{}` |
+| `headlessService.annotations` | Service annotations | `{}` |
 | `ingress.enabled` | Enable Ingress controller resource for HTTP traffic | `false` |
 | `ingress.labels` | HTTP Ingress labels | `{}` |
 | `ingress.annotations` | HTTP Ingress annotations | `{}` |

--- a/charts/refinery/templates/headless-service.yaml
+++ b/charts/refinery/templates/headless-service.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.headlessService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "refinery.fullname" . }}-headless
+  labels:
+    {{- include "refinery.labels" . | nindent 4 }}
+    {{- with .Values.headlessService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.headlessService.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.headlessService.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "refinery.selectorLabels" . | nindent 4 }}
+{{- end}}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -306,6 +306,12 @@ service:
   labels: {}
   annotations: {}
 
+headlessService:
+  enabled: false
+  grpcPort: 4317
+  labels: {}
+  annotations: {}
+
 ingress:
   enabled: false
   labels: {}


### PR DESCRIPTION
### Which problem is this PR solving?
Exposes a headless service for clients which supports client-side load balancing for gRPC traffic. The current gRPC ingress requires a gRPC compliant ingress controller running in the cluster. Having an optional headless service enables clients which support client-side load balancing to work out of the box.

### Short description of the changes
Added new headless service for gRPC clients which is disabled by default in the chart.