### PR TITLE
maint: use supported ubuntu image for circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   release-charts:
-    machine: true
+    machine:
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Closes #122 

CircleCI machine executor when set to `machine: true` uses Ubuntu 14.04 image which is [being deprecated](https://circleci.com/blog/ubuntu-14-16-image-deprecation/). Following [Circle guidance for migration](https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/), the image is now specified as the supported Ubuntu 20.04.