### PR TITLE
[refinery] Bump image to v1.11.0

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.6.0
-appVersion: 1.11.0
+appVersion: 1.12.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.6.0
-appVersion: 1.10.0
+appVersion: 1.11.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -95,6 +95,13 @@ config:
   UpstreamBufferSize: 1000
   PeerBufferSize: 1000
 
+  # EnvironmentCacheTTL is the amount of time a cache entry will live that associates
+  # an API key with an environment name.
+  # Cache misses lookup the environment name using HoneycombAPI config value.
+  # Default is 1 hour ("1h").
+  # Not eligible for live reload.
+  EnvironmentCacheTTL: "1h"
+
   # Configure how Refinery peers are discovered and managed
   PeerManagement:
     # The type should always be redis when deployed to Kubernetes environments


### PR DESCRIPTION
Updates the Refinery chart's image to use the latest (v1.11.0).

- Closes #124 

Includes adding `EnvironmentCacheTTL` to values.yaml.