### PR TITLE
[refinery] add readiness probe

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -76,6 +76,16 @@ spec:
             httpGet:
               path: /alive
               port: data
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            initialDelaySeconds: 0
+            periodSeconds: 3
+            failureThreshold: 5
           resources:
       {{- toYaml .Values.resources | nindent 12 }}
       volumes:


### PR DESCRIPTION
### Description
Whena refinery node is starting up, it can take a few seconds for it to load configuration and wait for external resources to become available (eg redis). During this start-up time, refinery should not receive traffic.

This change introduces two parts:
1) The livenessProbe now has an `initialDelaySeconds` of 10 seconds so it doesn't test if a node is alive straight away
2) Adds a readinessProbe to wait on a new node reporting it's ready before marking it healtly using periodSeconds of `3` and failureThreshold of `5`, giving it a total of `15` seconds to become ready before K8s will restart the node

- Closes #128

### Changes
- Add initialDelaySeconds of `10` to livenessProbe so it doesn't check a node before it's ready, also adds periodSeconds `10` & failureThreshold `3` which are the default values
- Adds readiness probe woth periodSeconds `3` & failureThreshold `5` and uses the default initialDelaySeconds of `10`
