### PR TITLE
[refinery] bump app version to 1.12.1

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.7.0
-appVersion: 1.12.0
+appVersion: 1.12.1
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
https://github.com/honeycombio/refinery/releases/tag/v1.12.1
in this release:
- fix error log to match event metadata