### PR TITLE
Add ingressClassName to refinery

### DIFF
--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -26,6 +26,9 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/refinery/templates/ingress-grpc.yaml
+++ b/charts/refinery/templates/ingress-grpc.yaml
@@ -24,6 +24,9 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- range .Values.grpcIngress.hosts }}
     - host: {{ .host | quote }}

--- a/charts/refinery/templates/ingress.yaml
+++ b/charts/refinery/templates/ingress.yaml
@@ -24,6 +24,9 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}


### PR DESCRIPTION
This adds support to refinery for [ingressClassName](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) which is a more recent feature of Kubernetes.