### PR TITLE
[refinery] update to refinery v1.13.0 with nested fields

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.8.0
-appVersion: 1.12.1
+appVersion: 1.13.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/sample-configs/rules_complete.yaml
+++ b/charts/refinery/sample-configs/rules_complete.yaml
@@ -210,6 +210,8 @@ dataset3:
 
 dataset4:
   Sampler: RulesBasedSampler
+  # Optional, if set to true then the rules will also check nested json fields, in the format of parent.child
+	CheckNestedFields: false
   rule:
     - name: 500 errors
       SampleRate: 1


### PR DESCRIPTION
update refinery chart appVersion to [v1.13.0](https://github.com/honeycombio/refinery/releases/tag/v1.13.0).

This version adds parsing for nested json fields in the rules sampler.