### PR TITLE
Prep Secure Tenancy 1.2.0

### DIFF
--- a/charts/secure-tenancy/CHANGELOG.md
+++ b/charts/secure-tenancy/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Secure Tenancy Helm Chart Changelog
 
+## Secure Tenancy v1.2.0
+
+- support ingressClassName (#105) | [@kentquirk](https://github.com/kentquirk)
 ## Secure Tenancy v1.1.0
 
 - update ST chart to support 1.12.1 (#103) | [@kentquirk](https://github.com/kentquirk)
-  - This updates the Secure Tenancy chart to support Release 1.12.1 of Secure Tenancy, including adding support for the new max_parallelism configuration value 
+  - This updates the Secure Tenancy chart to support Release 1.12.1 of Secure Tenancy, including adding support for the new max_parallelism configuration value
 
 ## Secure Tenancy v1.0.0
 


### PR DESCRIPTION
This preps the release of the Secure Tenancy chart to 1.2.0. Note that the version change had already been committed to Chart.yaml.