### PR TITLE
[oopentelemetry-collector] bump collector to 0.52.0

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -3,7 +3,7 @@ name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
 version: 1.1.0
-appVersion: 0.43.0
+appVersion: 0.52.0
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
Updates the OpenTelemetry chart app version to latest (0.52.0).