### PR TITLE
[opentelemetry-collector] prepare 1.2.0 release

### DIFF
--- a/charts/opentelemetry-collector/CHANGELOG.md
+++ b/charts/opentelemetry-collector/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenTelemetry Collector Helm Chart Changelog
 
+## OpenTelemetry Collector v1.2.0
+
+- Update OpenTelemetry Collector to 0.52.0 (#143)
+
 ## OpenTelemetry Collector v1.1.0
 
 - Update OpenTelemetry Collector to v0.43.0 (#106)

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: 0.52.0
 keywords:
   - observability


### PR DESCRIPTION
### What is this PR solving?

Prepares the v1.2.0 release of the OpenTelemetry Collector chart.

### Describe the changes

- Updates chart version to 1.2.0
- Adds changelog entry