### PR TITLE
[Refinery] Enable extra volume configurations in deployment config

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -72,6 +72,9 @@ spec:
           volumeMounts:
             - name: refinery-config
               mountPath: /etc/refinery/
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /alive
@@ -102,6 +105,9 @@ spec:
                   items:
                     - key: rules.yaml
                       path: rules.yaml
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -48,7 +48,7 @@ environment: [ ]
   #       name: honeycomb
   #       key: api-key
 
-# Use this in conjunction with `.Values.extraVolumes` to map additional volumes into the Refinery pods 
+# Use to map additional volumes into the Refinery pods 
 # Useful for volume-based secrets
 extraVolumeMounts: [ ]
   # - name: honeycomb-secrets

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -55,7 +55,7 @@ extraVolumeMounts: [ ]
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
 
-# Use this in conjunction with `.Values.extraVolumeMounts` to map additional volumes into the Refinery pods 
+# Use to map additional volumes into the Refinery pods 
 extraVolumes: [ ]
   # - name: honeycomb-secrets
   #   csi:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -48,6 +48,22 @@ environment: [ ]
   #       name: honeycomb
   #       key: api-key
 
+# Use this in conjunction with `.Values.extraVolumes` to map additional volumes into the Refinery pods 
+# Useful for volume-based secrets
+extraVolumeMounts: [ ]
+  # - name: honeycomb-secrets
+  #   mountPath: "/mnt/secrets-store"
+  #   readOnly: true
+
+# Use this in conjunction with `.Values.extraVolumeMounts` to map additional volumes into the Refinery pods 
+extraVolumes: [ ]
+  # - name: honeycomb-secrets
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "honeycomb-secrets"
+
 # Values used to build config.yaml.
 # See the example in sample-configs/config_complete.yaml for full details on all properties
 config:


### PR DESCRIPTION
## Which problem is this PR solving?

These changes enable users to define additional `volume` and `volumeMount` configurations for the Refinery deployment object. This is important to enable volume-based secrets handling techniques such as the [secrets-store-csi-driver](https://secrets-store-csi-driver.sigs.k8s.io/).

## Short description of the changes

Adds two new helm values: `volumes: [ ]` and `volumeMounts: [ ]`, uses the existing patterns to call the values using `toYaml` and `nindent`.

## How to verify that this has the expected result

From `./charts/refinery`, I am able to confirm that the chart renders properly _without_ the values set:

```
% helm template -f values.yaml .
```

and _with_ the values set:

```
% cat /tmp/volumes.values.yaml  
extraVolumeMounts:
  - name: honeycomb-secrets
    mountPath: "/mnt/secrets-store"
    readOnly: true

extraVolumes:
  - name: honeycomb-secrets
    csi:
      driver: secrets-store.csi.k8s.io
      readOnly: true
      volumeAttributes:
        secretProviderClass: "honeycomb-secrets"

% helm template -f values.yaml -f /tmp/volumes.values.yaml .
```