### PR TITLE
[honeycomb] bump k8s agent app version to 2.5.2

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
 version: 1.5.0
-appVersion: 2.5.0
+appVersion: 2.5.2
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
## Short description of the changes

- bump appVersion to [2.5.2](https://github.com/honeycombio/honeycomb-kubernetes-agent/releases/tag/v2.5.2) in `Chart.yaml` for honeycomb kubernetes agent 