### PR TITLE
[honeycomb] prep honeycomb kubernetes agent chart version 1.5.1

### DIFF
--- a/charts/honeycomb/CHANGELOG.md
+++ b/charts/honeycomb/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Honeycomb Kubernetes Agent Helm Chart Changelog
 
+## Honeycomb Kubernetes Agent v1.5.1
+
+- Bump kubernetes agent version to [2.5.2](https://github.com/honeycombio/honeycomb-kubernetes-agent/releases/tag/v2.5.2) (#148)
+  - Update to Go 1.18
+  - Only return cpu.utilization if a limit was provided
+
 ## Honeycomb Kubernetes Agent v1.5.0
 
 - Bump agent version to [2.5.0](https://github.com/honeycombio/honeycomb-kubernetes-agent/releases/tag/v2.5.0) (#133)

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.5.0
+version: 1.5.1
 appVersion: 2.5.2
 keywords:
   - observability


### PR DESCRIPTION
## Short description of the changes

- update version of honeycomb kubernetes agent chart to 1.5.1
- add changelog entry