### PR TITLE
Make otlp-http come 'first' in the list of ports, since it healthchecks

### DIFF
--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -11,8 +11,16 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
+    {{- if and (index .Values.ports "otlp-http") ((index .Values.ports "otlp-http" ).enabled) }}
+    {{- with (index .Values.ports "otlp-http") }}
+    - name: otlp-http
+      port: {{ .servicePort }}
+      targetPort: otlp-http
+      protocol: {{ .protocol }}
+    {{- end }}
+    {{- end }}
     {{- range $key, $port := .Values.ports }}
-    {{- if $port.enabled }}
+    {{- if and $port.enabled (ne $key "otlp-http") }}
     - name: {{ $key }}
       port: {{ $port.servicePort }}
       targetPort: {{ $key }}


### PR DESCRIPTION
This seems like an unfortunate generalization, but ... discussion
happening internally.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>

- Closes #<enter issue here>

## Short description of the changes

## How to verify that this has the expected result
