### PR TITLE
Add helm namespace to templates

### DIFF
--- a/charts/opentelemetry-collector/templates/configmap.yaml
+++ b/charts/opentelemetry-collector/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 data:

--- a/charts/opentelemetry-collector/templates/deployment.yaml
+++ b/charts/opentelemetry-collector/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/hpa.yaml
+++ b/charts/opentelemetry-collector/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 spec:

--- a/charts/opentelemetry-collector/templates/secret.yaml
+++ b/charts/opentelemetry-collector/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: honeycomb-{{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "opentelemetry-collector.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/opentelemetry-collector/templates/service.yaml
+++ b/charts/opentelemetry-collector/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "opentelemetry-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/charts/opentelemetry-collector/templates/serviceaccount.yaml
+++ b/charts/opentelemetry-collector/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opentelemetry-collector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opentelemetry-collector.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes #146

While helm install can respect the kubectl context namespace or accept a namespace flag, when using helm template, this information is lost if not persisted to the generated files. This means tooling that requires a helm template -> kubectl install has to work around the missing namespace.

## Short description of the changes

Adds in the default `.Release.Namespace` value to the namespace for each namespace resource. https://helm.sh/docs/chart_template_guide/builtin_objects/ . Similar changes have been made such as https://github.com/helm/charts/pull/17937/files#diff-4dcbfca5f8fd1c82a179cf60e0448926548323d101f0321679e2fd1e3a2dc665R12  found on the original issue https://github.com/helm/helm/issues/5465

## How to verify that this has the expected result


```
❯ kns
Context "ngrok-dev-us" modified.
Active namespace is "default".
❯ helm template ./charts/opentelemetry-collector | grep -i namespace
  namespace: default
  namespace: default
  namespace: default
  namespace: default
  namespace: default
❯ kns
Context "ngrok-dev-us" modified.
Active namespace is "kube-system".
❯ helm template ./charts/opentelemetry-collector | grep -i namespace
  namespace: kube-system
  namespace: kube-system
  namespace: kube-system
  namespace: kube-system
  namespace: kube-system

```
