### PR TITLE
update honeycomb k8s agent to 2.5.3

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
 version: 1.5.1
-appVersion: 2.5.2
+appVersion: 2.5.3
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Updates [honeycomb-kubernetes-agent](https://github.com/honeycombio/honeycomb-kubernetes-agent) to 2.5.3 which has a fix for the latest OpenSSL CVE.

- Closes https://github.com/honeycombio/telemetry-team/issues/263

## Short description of the changes
- Updates `appVersion` in the Honeycomb helm chart to 2.5.3

## How to verify that this has the expected result
The 2.5.3 was a no-op release that was made to rebuild the docker image so there should be no changes in any functionality.