### PR TITLE
[opentelemetry-collector] Swap order of hpa spec.metrics

### DIFF
--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 1.2.1
+version: 1.2.0
 appVersion: 0.52.0
 keywords:
   - observability

--- a/charts/opentelemetry-collector/Chart.yaml
+++ b/charts/opentelemetry-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opentelemetry-collector
 description: OpenTelemetry Collector for Honeycomb
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 0.52.0
 keywords:
   - observability

--- a/charts/opentelemetry-collector/templates/hpa.yaml
+++ b/charts/opentelemetry-collector/templates/hpa.yaml
@@ -14,16 +14,16 @@ spec:
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
-  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
-  {{- end }}
   {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+  {{- end }}
+  {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Really this is for https://github.com/argoproj/argo-cd/issues/1079 which points blame at upstream k8s.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

https://github.com/argoproj/argo-cd/issues/1079
This issue points at upstream k8s as the problem, but for the moment it's easier to request a change here that matches the output of the HPA object

## Short description of the changes
Swapping the CPU and memory metric for the HPA

## How to verify that this has the expected result
Nothing should change other than the resulting order of the rendered template