### PR TITLE
Use correct syntax in commented out field

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -133,7 +133,7 @@ config:
     # If the environment variable 'REFINERY_REDIS_USERNAME' is set it takes
     # precedence and this value is ignored.
     # Not eligible for live reload.
-    # RedisUsername = ""
+    # RedisUsername: ""
 
     # RedisPassword is the password used to connect to redis for peer cluster membership management.
     # If the environment variable 'REFINERY_REDIS_PASSWORD' is set it takes


### PR DESCRIPTION
## Which problem is this PR solving?

Without this if you removed the comment in front of `RedisUsername` it would be a YAML syntax error.
<please describe the issue>
