### PR TITLE
separate yaml layers to help parsing

### DIFF
--- a/charts/refinery/sample-configs/rules_complete.yaml
+++ b/charts/refinery/sample-configs/rules_complete.yaml
@@ -244,14 +244,15 @@ dataset4:
         - field: status_code
           operator: '='
           value: 200
-      sampler.EMADynamicSampler:
-        Sampler: "EMADynamicSampler"
-        GoalSampleRate: 15
-        FieldList:
-          - "request.method"
-          - "request.route"
-        AddSampleRateKeyToTrace: true
-        AddSampleRateKeyToTraceField: "meta.refinery.dynsampler_key"
+      sampler:
+        EMADynamicSampler:
+          Sampler: "EMADynamicSampler"
+          GoalSampleRate: 15
+          FieldList:
+            - "request.method"
+            - "request.route"
+          AddSampleRateKeyToTrace: true
+          AddSampleRateKeyToTraceField: "meta.refinery.dynsampler_key"
 
     - name: "sample traces originating from a service"
       scope: "span"


### PR DESCRIPTION
Refinery would reject the EMADynamic Sampler rule without this change.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?


Yaml parser doesn't like the dot in the middle of multiple fields.

## Short description of the changes

Fixing the parser is a bit beyond my skill level.
Simplifying the example so it works is the sweet spot.

## How to verify that this has the expected result

Run refinery in debug mode with a breakpoint in the rule parser to see that line fail to parse in the old config and succeed in the new config.