### PR TITLE
fix: Remove obsolete dash from configmap names

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -102,9 +102,9 @@ spec:
                       path: config.yaml
               - configMap:
                 {{- if .Values.config.RulesConfigMapName }}
-                - name: {{ .Values.config.RulesConfigMapName }}
+                  name: {{ .Values.config.RulesConfigMapName }}
                 {{- else }}
-                - name: {{ include "refinery.fullname" . }}-rules
+                  name: {{ include "refinery.fullname" . }}-rules
                 {{- end }}
                   items:
                     - key: rules.yaml

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -242,7 +242,7 @@ rules:
   # DryRun - If enabled, marks traces that would be dropped given current sampling rules,
   # and sends all traces regardless
   # DryRun: false
-
+  # lb:
   # This is the default sampler used.
   # Any traces received that are not for a defined dataset will use this sampler.
   # Deterministic Sampler implementation. This is the simplest sampling algorithm
@@ -262,11 +262,11 @@ rules:
   #
   # This example creates a sampling definition for a dataset called: test-dataset
   # test-dataset:
-    # Sampler: EMADynamicSampler
-    # GoalSampleRate: 5
-    # FieldList:
-    #  - request.method
-    #  - response.status_code
+  #   Sampler: EMADynamicSampler
+  #   GoalSampleRate: 5
+  #   FieldList:
+  #    - request.method
+  #    - response.status_code
 
   # LiveReload - If disabled, triggers a rolling restart of the cluster whenever
   # the Rules configmap changes


### PR DESCRIPTION
## Which problem is this PR solving?

```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.volumes[0].projected.sources[1].configMap): invalid type for io.k8s.api.core.v1.ConfigMapProjection: got "array", expected "map"
```

- Closes #<enter issue here>

## Short description of the changes

Remove obsolete dash from configmap names within `deployment.yaml` template

## How to verify that this has the expected result

Run below
```
helm install refinery ./refinery
```

expected output

```
NAME: refinery
LAST DEPLOYED: Tue Aug 23 13:05:18 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing
within a few minutes at https://ui.honeycomb.io
```
