### PR TITLE
Add Helm namespace metadata

### DIFF
--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "refinery.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
 data:

--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -3,7 +3,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "refinery.fullname" . }}-rules
+  name: {{ include "refinery.fullname" . }}-rule
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
 data:

--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "refinery.fullname" . }}-rule
+  name: {{ include "refinery.fullname" . }}-rules
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -2,7 +2,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "refinery.redis.fullname" . }}
+  name: {{ include "refinery.redis.fullname" . }
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.redis.labels" . | nindent 4 }}
 spec:

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "refinery.redis.fullname" . }
+  name: {{ include "refinery.redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.redis.labels" . | nindent 4 }}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "refinery.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
 spec:

--- a/charts/refinery/templates/hpa.yaml
+++ b/charts/refinery/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "refinery.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
 spec:

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/refinery/templates/ingress-grpc.yaml
+++ b/charts/refinery/templates/ingress-grpc.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-grpc
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
     {{- with .Values.grpcIngress.labels }}

--- a/charts/refinery/templates/ingress.yaml
+++ b/charts/refinery/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/charts/refinery/templates/service-redis.yaml
+++ b/charts/refinery/templates/service-redis.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "refinery.redis.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.redis.labels" . | nindent 4 }}
 spec:

--- a/charts/refinery/templates/service.yaml
+++ b/charts/refinery/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "refinery.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/refinery/templates/serviceaccount.yaml
+++ b/charts/refinery/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "refinery.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.labels }}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

This allows generating the namespace and have it defined based on the kubectl client's namespace flag

## Which problem is this PR solving?

See Issue https://github.com/honeycombio/helm-charts/issues/146 for context around the problem

- Closes [#157](https://github.com/honeycombio/helm-charts/issues/157)

Please see the same PR for the Collector which makes the same changes: https://github.com/honeycombio/helm-charts/pull/155
