### PR TITLE
Calculate `MaxAlloc` based on pod memory request.

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -123,9 +123,14 @@ is capable to handle a modest sampling load and should be configured based on yo
 are largely based on the velocity of spans received per second, and the average number of spans per trace. Other settings
 such as rule complexity and trace duration timeouts will also have an effect on scaling requirements.
 
-The primary setting that control scaling are `replicaCount` and `resources.limits`. When changing `resources.limits.memory`,
-you must also change `config.InMemCollector.MaxAlloc`. This should be set to 80% of the available memory for each replica.
-Refer to the comments in [values.yaml](./values.yaml) for more details about each property.
+The primary settings that control scaling are `replicaCount` and
+`resources.limits`. By default, this chart will auto-configure Refinery's
+`MaxAlloc` to 75% of each pod's `resources.limits.requests.memory` setting.
+
+If setting `config.InMemCollector.MaxAlloc` explicitly, you must ensure that the
+value is nor more than 80% of the memory requested for each replica. Refer to
+the comments in [values.yaml](./values.yaml) for more details about each
+property.
 
 See [Refinery: Scale and Troubleshoot](https://docs.honeycomb.io/manage-data-volume/refinery/scale-and-troubleshoot/)
 for more details on how to properly scale Refinery.

--- a/charts/refinery/templates/_config.tpl
+++ b/charts/refinery/templates/_config.tpl
@@ -1,0 +1,10 @@
+{{/*
+Merge user-supplied `MaxAlloc` if present. Otherwise, calculate the value.
+*/}}
+{{- define "refinery.config.InMemCollector" -}}
+{{- $InMemCollectorAlloc := get .Values.config.InMemCollector "MaxAlloc" }}
+{{- if (not $InMemCollectorAlloc) }}
+{{- $_ := set $InMemCollectorAlloc "MaxAlloc" (mulf .Values.resources.requests.memory 0.75) }}
+{{- end }}
+{{- .Values.config | toYaml }}
+{{- end }}

--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -6,4 +6,36 @@ metadata:
   {{- include "refinery.labels" . | nindent 4 }}
 data:
   config.yaml: |
-{{- toYaml .Values.config | nindent 4 }}
+    EnvironmentCacheTTL: {{ .Values.config.EnvironmentCacheTTL }}
+    GRPCListenAddr: {{ .Values.config.GRPCListenAddr }}
+    HoneycombAPI: {{ .Values.config.HoneycombAPI }}
+    InMemCollector:
+      CacheCapacity: {{ .Values.config.InMemCollector.CacheCapacity }}
+
+      {{- if hasKey .Values.config.InMemCollector "MaxAlloc" }}
+      MaxAlloc: {{ .Values.config.InMemCollector.MaxAlloc }}
+      {{ else }}
+      MaxAlloc: {{ mulf .Values.resources.requests.memory 0.8 }}
+      {{- end }}
+
+    ListenAddr: {{ .Values.config.ListenAddr }}
+    Logger: {{ .Values.config.Logger }}
+    LoggingLevel: {{ .Values.config.LoggingLevel }}
+    MaxBatchSize: {{ .Values.config.MaxBatchSize }}
+    Metrics: {{ .Values.config.Metrics }}
+    PeerBufferSize: {{ .Values.config.PeerBufferSize }}
+    PeerListenAddr: {{ .Values.config.PeerListenAddr }}
+    PeerManagement:
+      IdentifierInterfaceName: {{ .Values.config.PeerManagement.IdentifierInterfaceName }}
+      RedisHost: {{ .Values.config.PeerManagement.RedisHost }}
+      RedisPassword: "{{ .Values.config.PeerManagement.RedisPassword }}"
+      Type: {{ .Values.config.PeerManagement.Type }}
+      UseIPV6Identifier: {{ .Values.config.PeerManagement.UseIPV6Identifier }}
+      UseTLS: {{ .Values.config.PeerManagement.UseTLS }}
+    PrometheusMetrics:
+      MetricsListenAddr: {{ .Values.config.PrometheusMetrics.MetricsListenAddr }}
+    RulesConfigMapName: "{{ .Values.config.RulesConfigMapName }}"
+    SendDelay: {{ .Values.config.SendDelay }}
+    SendTicker: {{ .Values.config.SendTicker }}
+    TraceTimeout: {{ .Values.config.TraceTimeout }}
+    UpstreamBufferSize: {{ .Values.config.UpstreamBufferSize }}

--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -15,7 +15,7 @@ data:
       {{- if hasKey .Values.config.InMemCollector "MaxAlloc" }}
       MaxAlloc: {{ .Values.config.InMemCollector.MaxAlloc }}
       {{ else }}
-      MaxAlloc: {{ mulf .Values.resources.requests.memory 0.8 }}
+      MaxAlloc: {{ mulf .Values.resources.requests.memory 0.75 }}
       {{- end }}
 
     ListenAddr: {{ .Values.config.ListenAddr }}

--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -7,36 +7,4 @@ metadata:
   {{- include "refinery.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    EnvironmentCacheTTL: {{ .Values.config.EnvironmentCacheTTL }}
-    GRPCListenAddr: {{ .Values.config.GRPCListenAddr }}
-    HoneycombAPI: {{ .Values.config.HoneycombAPI }}
-    InMemCollector:
-      CacheCapacity: {{ .Values.config.InMemCollector.CacheCapacity }}
-
-      {{- if hasKey .Values.config.InMemCollector "MaxAlloc" }}
-      MaxAlloc: {{ .Values.config.InMemCollector.MaxAlloc }}
-      {{ else }}
-      MaxAlloc: {{ mulf .Values.resources.requests.memory 0.75 }}
-      {{- end }}
-
-    ListenAddr: {{ .Values.config.ListenAddr }}
-    Logger: {{ .Values.config.Logger }}
-    LoggingLevel: {{ .Values.config.LoggingLevel }}
-    MaxBatchSize: {{ .Values.config.MaxBatchSize }}
-    Metrics: {{ .Values.config.Metrics }}
-    PeerBufferSize: {{ .Values.config.PeerBufferSize }}
-    PeerListenAddr: {{ .Values.config.PeerListenAddr }}
-    PeerManagement:
-      IdentifierInterfaceName: {{ .Values.config.PeerManagement.IdentifierInterfaceName }}
-      RedisHost: {{ .Values.config.PeerManagement.RedisHost }}
-      RedisPassword: "{{ .Values.config.PeerManagement.RedisPassword }}"
-      Type: {{ .Values.config.PeerManagement.Type }}
-      UseIPV6Identifier: {{ .Values.config.PeerManagement.UseIPV6Identifier }}
-      UseTLS: {{ .Values.config.PeerManagement.UseTLS }}
-    PrometheusMetrics:
-      MetricsListenAddr: {{ .Values.config.PrometheusMetrics.MetricsListenAddr }}
-    RulesConfigMapName: "{{ .Values.config.RulesConfigMapName }}"
-    SendDelay: {{ .Values.config.SendDelay }}
-    SendTicker: {{ .Values.config.SendTicker }}
-    TraceTimeout: {{ .Values.config.TraceTimeout }}
-    UpstreamBufferSize: {{ .Values.config.UpstreamBufferSize }}
+  {{- toYaml .Values.config | nindent 4 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -19,7 +19,7 @@ resources:
   limits:
     cpu: 2000m
     # Changing memory limits requires updating config.InMemCollector.MaxAlloc
-    memory: 2097152000 # use bytes to allow auto-configuration of `MaxAlloc`
+    memory: 2147483648 # use bytes to allow auto-configuration of `MaxAlloc`
   requests:
     cpu: 500m
     memory: 524288000 # use bytes to allow auto-configuration of `MaxAlloc`

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -19,10 +19,10 @@ resources:
   limits:
     cpu: 2000m
     # Changing memory limits requires updating config.InMemCollector.MaxAlloc
-    memory: 2Gi
+    memory: 2097152000 # use bytes to allow auto-configuration of `MaxAlloc`
   requests:
     cpu: 500m
-    memory: 500Mi
+    memory: 524288000 # use bytes to allow auto-configuration of `MaxAlloc`
 
 image:
   repository: honeycombio/refinery
@@ -176,7 +176,7 @@ config:
     # This value should be set in according to the resources.limits.memory
     # By default that setting is 2GB, and this is set to 85% of that limit
     # 2 * 1024 * 1024 * 1024 * 0.80 = 1,717,986,918
-    MaxAlloc: 1717986918
+    # MaxAlloc: 42
 
   # Logger describes which logger to use for Refinery logs. Valid options are
   # "logrus" and "honeycomb". The logrus option will write logs to STDOUT and the

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -176,7 +176,7 @@ config:
     # This value should be set in according to the resources.limits.memory
     # By default that setting is 2GB, and this is set to 85% of that limit
     # 2 * 1024 * 1024 * 1024 * 0.80 = 1,717,986,918
-    # MaxAlloc: 42
+    # MaxAlloc: 1717986918
 
   # Logger describes which logger to use for Refinery logs. Valid options are
   # "logrus" and "honeycomb". The logrus option will write logs to STDOUT and the


### PR DESCRIPTION
If `config.InMemCollector.MaxAlloc` is set explictly, use that value instead.

## Which problem is this PR solving?

It's tedious to manually-calculate the value of `MaxAlloc` when experimenting with Refinery memory tunings.

This PR doesn't address any specific GitHub issues, and is based on brief chats with various Honeycomb employees on public Slack. Keeping as a draft until feedback is recieved.

The chart version has not been bumped out of respect for Honeycomb's internal versioning process.


## Short description of the changes

This PR aims to do the following:

- Calculate a safe value for `MaxAlloc` automatically
- Accept an explicit override if one is present.

## How to verify that this has the expected result

Run

```
helm template charts/refinery | grep MaxAlloc
      MaxAlloc: 4.194304e+08

helm template charts/refinery --set config.InMemCollector.MaxAlloc=42 | grep MaxAlloc
      MaxAlloc: 42
```

## Potential Drawbacks

Due to the minimal nature of math functions in Helm, we don't currently handle string values for memory resources, only resources denoted in bytes as an integer.