### PR TITLE
[honeycomb] update k8s agent version to v2.5.4

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
 version: 1.5.2
-appVersion: 2.5.3
+appVersion: 2.5.4
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Updates the Honeycomb Kubernetes Agent app version to latest.

## Short description of the changes
- updates app version to 2.5.4

## How to verify that this has the expected result
- Using the chart uses the latest version of the Kubernetes agent