### PR TITLE
[honeycomb] Prepare v1.5.3 release

### DIFF
--- a/charts/honeycomb/CHANGELOG.md
+++ b/charts/honeycomb/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb Kubernetes Agent Helm Chart Changelog
 
+## Honeycomb Kubernetes Agent v1.5.3
+
+- Bump kubernetes agent version to [2.5.4](https://github.com/honeycombio/honeycomb-kubernetes-agent/releases/tag/v2.5.4) (#148)
+  - Bump dependencies, including libhoney
+
 ## Honeycomb Kubernetes Agent v1.5.2
 
 - Add helm namespace to templates (#155) | @alex-bezek

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.5.2
+version: 1.5.3
 appVersion: 2.5.4
 keywords:
   - observability


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Prepares the honeycomb kubernetes agent v1.5.3 release.

## Short description of the changes

- Update chart version to 1.5.3
- Add changelog entry
