### PR TITLE
fix: Use distinct annotation keys for checksums

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         prometheus.io/scrape: "true"
         {{- end }}
         {{- if hasKey .Values.rules "LiveReload" | ternary (not .Values.rules.LiveReload) false }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
+        checksum/rules: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- end }}
       labels:
       {{- include "refinery.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Currently both checksums use the same key, so only one is present in the resulting Deployment. This is leading to our Deployments not restarting on rule changes.

## Short description of the changes

Change the key for the rules so it's distinct from the one for config.

## How to verify that this has the expected result

Deploy the chart, observe that there are now 2 checksum annotations on the Pod instead of only one.