### PR TITLE
[refinery] Update to set redis host based on release name

### DIFF
--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -7,4 +7,4 @@ metadata:
   {{- include "refinery.labels" . | nindent 4 }}
 data:
   config.yaml: |
-{{- toYaml .Values.config | nindent 4 }}
+{{- tpl (toYaml .Values.config) . | nindent 4 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -164,7 +164,7 @@ config:
     # Further, if the environment variable 'REFINERY_REDIS_HOST' is set it takes
     # precedence and this value is ignored.
     # Not eligible for live reload.
-    RedisHost: "refinery-redis:6379"
+    RedisHost: '{{include "refinery.redis.fullname" .}}:6379'
 
     # RedisUsername is the username used to connect to redis for peer cluster membership management.
     # If the environment variable 'REFINERY_REDIS_USERNAME' is set it takes

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -66,6 +66,8 @@ extraVolumes: [ ]
 
 # Values used to build config.yaml.
 # See the example in sample-configs/config_complete.yaml for full details on all properties
+# Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
+# For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED }} `}}.
 config:
   # ListenAddr is the IP and port on which to listen for incoming events.
   ListenAddr: 0.0.0.0:8080
@@ -164,6 +166,8 @@ config:
     # Further, if the environment variable 'REFINERY_REDIS_HOST' is set it takes
     # precedence and this value is ignored.
     # Not eligible for live reload.
+    # RedisHost will default to the name used for the release or name overrides depending on what is used,
+    # but can be overriden to a specific value.
     RedisHost: '{{include "refinery.redis.fullname" .}}:6379'
 
     # RedisUsername is the username used to connect to redis for peer cluster membership management.

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -67,7 +67,7 @@ extraVolumes: [ ]
 # Values used to build config.yaml.
 # See the example in sample-configs/config_complete.yaml for full details on all properties
 # Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
-# For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED }} `}}.
+# For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
 config:
   # ListenAddr is the IP and port on which to listen for incoming events.
   ListenAddr: 0.0.0.0:8080


### PR DESCRIPTION
## Which problem is this PR solving?

Currently the refinery chart must be installed with a release name of `refinery` or the `.Values.config.PeerManagement.RedisHost` must be manually updated to match the release name.  This works if you know what the release name will be, but for situations like chart-testing, the release name is dynamically generated.  It is also problematic when using the chart for the first time; if you want to use the default values.yaml you must use `refinery` as the release name.

## Short description of the changes

Updates `.Values.config` to be run through the `tpl` function.  This allows us to set `RedisHost: '{{include "refinery.redis.fullname" .}}:6379'` in the values.yaml and us the chart's fullname helpers to determine the default RedisHost.

## How to verify that this has the expected result

Deployed refinery local and ran it through chart-testing.