### PR TITLE
avoid checksum/config collision

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         prometheus.io/scrape: "true"
         {{- end }}
         {{- if hasKey .Values.rules "LiveReload" | ternary (not .Values.rules.LiveReload) false }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
+        checksum/rules: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- end }}
       labels:
       {{- include "refinery.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Refinery's config and rules checksums use the same key under the annotations so helm renders both but then kubernetes only keeps one. 

This can create a surprising behavior where `LiveReload: false` is set and the config is changed but the checksum doesn't change. 

## Short description of the changes

Changes the `checksum/config` key for the rules file to `checksum/rules` to allow each to be present. 

## How to verify that this has the expected result

The problematic helm output can be seen this way on the current main branch. 

```console
$ helm template refinery charts/refinery --set rules.LiveReload=false | grep -B2 -A3 checksum
    metadata:
      annotations:
        checksum/config: 5ca42dab30454750310f6949d0554a38f7c225dbdab822c3a5ffa90ed255e36c
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
        checksum/config: 84dd3c40cb9678ea16d51edd6e637a00e2c6565badc1e0856a93a46981246ae6
      labels:
        app.kubernetes.io/name: refinery
        app.kubernetes.io/instance: refinery
```

Deploy it to a cluster to see how Kubernetes folds them together, basically hiding the `config.yaml` changes. 

```console
$ helm install refinery charts/refinery --set rules.LiveReload=false
Release "refinery" has been upgraded. Happy Helming!
NAME: refinery
LAST DEPLOYED: Mon Oct 24 18:51:59 2022
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing
within a few minutes at https://ui.honeycomb.io
```

Check the yaml output in the deployment. 

```console
$ kubectl get deploy refinery -o yaml | grep -B3 -A3 checksum
  template:
    metadata:
      annotations:
        checksum/config: 84dd3c40cb9678ea16d51edd6e637a00e2c6565badc1e0856a93a46981246ae6
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      creationTimestamp: null
```

Any changes made to the values.yaml file under `config:` will not modify the checksum. LiveReload=false ends up hiding the configuration file's checksum.

Doing the same thing under this branch: 

```console
$ git checkout mterhar.refinery-restart-pods 
Switched to branch 'mterhar.refinery-restart-pods'
Your branch is up to date with 'origin/mterhar.refinery-restart-pods'.

$ helm upgrade refinery charts/refinery --set rules.LiveReload=false                         
Release "refinery" has been upgraded. Happy Helming!
NAME: refinery
LAST DEPLOYED: Mon Oct 24 18:58:53 2022
NAMESPACE: default
STATUS: deployed
REVISION: 3
TEST SUITE: None
NOTES:
Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing
within a few minutes at https://ui.honeycomb.io

$ helm template refinery charts/refinery --set rules.LiveReload=false | grep -B2 -A3 checksum
    metadata:
      annotations:
        checksum/config: 5ca42dab30454750310f6949d0554a38f7c225dbdab822c3a5ffa90ed255e36c
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
        checksum/rules: 84dd3c40cb9678ea16d51edd6e637a00e2c6565badc1e0856a93a46981246ae6
      labels:
        app.kubernetes.io/name: refinery
        app.kubernetes.io/instance: refinery

$ kubectl get deploy refinery -o yaml | grep -B3 -A3 checksum                                
  template:
    metadata:
      annotations:
        checksum/config: 5ca42dab30454750310f6949d0554a38f7c225dbdab822c3a5ffa90ed255e36c
        checksum/rules: 84dd3c40cb9678ea16d51edd6e637a00e2c6565badc1e0856a93a46981246ae6
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      creationTimestamp: null
```

No more collision. 