### PR TITLE
[refinery] bump app version to 1.19.0

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 1.15.1
-appVersion: 1.18.0
+appVersion: 1.19.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/ci/cache-overrun-strat-resize-values.yaml
+++ b/charts/refinery/ci/cache-overrun-strat-resize-values.yaml
@@ -1,0 +1,10 @@
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M
+  requests:
+    cpu: 100m
+    memory: 200M
+
+config:
+  CacheOverrunStrategy: resize

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -157,6 +157,16 @@ config:
   # Eligible for live reload.
   AddSpanCountToRoot: false
 
+  # CacheOverrunStrategy controls the cache management behavior under memory pressure.
+  # "resize" means that when a cache overrun occurs, the cache is shrunk and never grows again,
+  # which is generally not helpful unless it occurs because of a permanent change in traffic patterns.
+  # In the "impact" strategy, the items having the most impact on the cache size are
+  # ejected from the cache earlier than normal but the cache is not resized.
+  # In all cases, it only applies if MaxAlloc is nonzero.
+  # Default is "resize" for compatibility but "impact" is recommended for most installations.
+  # Eligible for live reload.
+  CacheOverrunStrategy: "impact"
+
   # Configure how Refinery peers are discovered and managed
   PeerManagement:
     # The type should always be redis when deployed to Kubernetes environments


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- [Refinery 1.19.0 is released!](https://github.com/honeycombio/refinery/releases/tag/v1.19.0)
- Updates refinery configuration options to be in line with what was added in refinery 1.19.0
- closes #202

## How to verify that this has the expected result

Installed the Refinery helm chart locally with the new config values 👍 
Added new CI scenario for `CacheOverrunStrategy: resize`
