### PR TITLE
chore: add nodeport to the service.yaml

### DIFF
--- a/charts/refinery/templates/service.yaml
+++ b/charts/refinery/templates/service.yaml
@@ -17,10 +17,16 @@ spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: data
+      {{- if not (empty .Values.service.httpNodePort) }}
+      nodePort: {{ .Values.service.httpNodePort }}
+      {{- end }}
       protocol: TCP
       name: data
     - port: {{ .Values.service.grpcPort }}
       targetPort: grpc
+      {{- if not (empty .Values.service.grpcNodePort) }}
+      nodePort: {{ .Values.service.grpcNodePort }}
+      {{- end }}
       protocol: TCP
       name: grpc
     {{- if eq .Values.config.Metrics "prometheus" }}


### PR DESCRIPTION
Port mapping is useful for testing refinery locally. Adding this to the `service.yaml` so that it does not need to manually be added by anyone needing to reference this helm chart. 