### PR TITLE
maint: bump honeycomb chart appVersion

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
 version: 1.7.0
-appVersion: 2.7.0
+appVersion: 2.7.1
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>

- Closes https://github.com/honeycombio/helm-charts/issues/233

## Short description of the changes

- Bumps default Honeycomb k8s agent version to 2.7.1

## How to verify that this has the expected result

CI tests
