### PR TITLE
feat: Added support for additional env variable settings

### DIFF
--- a/charts/honeycomb/README.md
+++ b/charts/honeycomb/README.md
@@ -38,6 +38,10 @@ watchers:
     labelSelector: component=kube-scheduler
     namespace: kube-system
     parser: glog
+# Optional your additional env settings
+additionalEnv:
+  - name: HTTP_PROXY
+    value: http://your-proxy-url.example:8080
 ```
 Then use this yaml file when installing the chart
 ```bash

--- a/charts/honeycomb/README.md
+++ b/charts/honeycomb/README.md
@@ -38,10 +38,6 @@ watchers:
     labelSelector: component=kube-scheduler
     namespace: kube-system
     parser: glog
-# Optional your additional env settings
-additionalEnv:
-  - name: HTTP_PROXY
-    value: http://your-proxy-url.example:8080
 ```
 Then use this yaml file when installing the chart
 ```bash

--- a/charts/honeycomb/templates/daemonset.yaml
+++ b/charts/honeycomb/templates/daemonset.yaml
@@ -62,8 +62,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            {{- if gt (len .Values.additionalEnv) 0 -}}
-              {{- toYaml .Values.additionalEnv | nindent 12}}
+            {{- with .Values.additionalEnv -}}
+              {{- . | toYaml | nindent 12}}
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/honeycomb/templates/daemonset.yaml
+++ b/charts/honeycomb/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
         {{- if not .Values.honeycomb.existingSecret }}
-        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}  
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
             {{- toYaml . | nindent 8 }}
@@ -62,6 +62,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- if gt (len .Values.additionalEnv) 0 -}}
+              {{- toYaml .Values.additionalEnv | nindent 12}}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -97,6 +97,10 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# You can add additional environment values like this:
+#additionalEnv:
+#  - name: var_name
+#    value: var_value
 
 nodeSelector: {}
 

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -98,7 +98,7 @@ resources: {}
   #   memory: 128Mi
 
 # Field for adding additional environment variables
-#additionalEnv:
+additionalEnv: {}
 #  - name: var_name
 #    value: var_value
 

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -97,7 +97,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# You can add additional environment values like this:
+# Field for adding additional environment variables
 #additionalEnv:
 #  - name: var_name
 #    value: var_value

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -97,7 +97,6 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-additionalEnv: {}
 
 nodeSelector: {}
 

--- a/charts/honeycomb/values.yaml
+++ b/charts/honeycomb/values.yaml
@@ -97,6 +97,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+additionalEnv: {}
+
 nodeSelector: {}
 
 # Tolerate agent to run on all nodes by default


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Adding additional custom env variables to honeycomb

- Closes #241

## Short description of the changes
extending config to read env variable from a user values file.

## How to verify that this has the expected result
adding proxy setting like this will add them to the chart
```yaml
additionalEnv:
  - name: HTTP_PROXY
    value: http://your-proxy-url.example:8080
```
