### PR TITLE
maint: fix secure-tenancy dependency url

### DIFF
--- a/charts/secure-tenancy/Chart.lock
+++ b/charts/secure-tenancy/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mariadb
-  repository: https://charts.bitnami.com/bitnami
-  version: 7.6.1
-digest: sha256:8eae6d7cb5b9ea45e39d81172b898a143940c42ca4ee945c80b9e72ccf8025a1
-generated: "2020-07-30T20:02:54.503797-04:00"
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 12.2.3
+digest: sha256:b7bb131e2bec8b5fc78f1f8f8ab4348f0a960e642dd693dd6261d69197ccac2f
+generated: "2023-05-12T11:44:58.175648-06:00"

--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -1,15 +1,15 @@
 apiVersion: v2
 name: secure-tenancy
 description: "Deprecated: Honeycomb Secure Tenancy"
-version: 1.2.1
+version: 1.2.2
 appVersion: 1.12.1
 keywords:
   - observability
   - security
 dependencies:
 - name: mariadb
-  version: 7.6.1
-  repository: https://charts.bitnami.com/bitnami
+  version: 12.2.3
+  repository: oci://registry-1.docker.io/bitnamicharts
   condition: mysql.enabled
   alias: mysql
 home: https://honeycomb.io


### PR DESCRIPTION
## Which problem is this PR solving?
The secure-tenancy 1.2.1 release didn't work bc the chart dependency no longer existed.  The packager needed to be able to pull the dependency to package and release the chart.

## Short description of the changes

Updates bitnami mariadb chart to latest version so releasing works.
