### PR TITLE
maint: Bump release tooling

### DIFF
--- a/.circleci/install_tools.sh
+++ b/.circleci/install_tools.sh
@@ -2,8 +2,8 @@
 
 set -o errexit
 
-readonly HELM_VERSION=3.5.2
-readonly CHART_RELEASER_VERSION=1.2.0
+readonly HELM_VERSION=3.12.0
+readonly CHART_RELEASER_VERSION=1.5.0
 
 echo "Installing Helm..."
 curl -LO "https://get.helm.sh/helm-v$HELM_VERSION-linux-amd64.tar.gz"

--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: secure-tenancy
 description: "Deprecated: Honeycomb Secure Tenancy"
-version: 1.2.2
+version: 1.2.3
 appVersion: 1.12.1
 keywords:
   - observability

--- a/charts/secure-tenancy/Chart.yaml
+++ b/charts/secure-tenancy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: secure-tenancy
 description: "Deprecated: Honeycomb Secure Tenancy"
-version: 1.2.3
+version: 1.2.2
 appVersion: 1.12.1
 keywords:
   - observability


### PR DESCRIPTION
## Which problem is this PR solving?

Updates our helm release tools to be up-to-date.  This is necessary to use oci repository urls.  See https://app.circleci.com/pipelines/github/honeycombio/helm-charts/645/workflows/d4873a2d-4a88-4b1c-b553-e8f186f61580/jobs/265

## Short description of the changes

Update to use latest helm and chart releaser

## How to verify that this has the expected result

Tested that cr package worked with these versions locally.
