### PR TITLE
maint: cleanup release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ jobs:
       - run:
           command: |
             echo "export GIT_USERNAME=$CIRCLE_USERNAME" >> $BASH_ENV
-            echo "export GIT_REPOSITORY_URL=$CIRCLE_REPOSITORY_URL" >> $BASH_ENV
             echo "export GIT_REPOSITORY_OWNER=$CIRCLE_PROJECT_USERNAME" >> $BASH_ENV
             echo "export GIT_REPOSITORY_NAME=$CIRCLE_PROJECT_REPONAME" >> $BASH_ENV
             .circleci/install_tools.sh

--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -6,10 +6,8 @@ set -o pipefail
 
 : "${GITHUB_TOKEN:?Environment variable GITHUB_TOKEN must be set}"
 : "${GIT_USERNAME:?Environment variable GIT_USERNAME must be set}"
-: "${GIT_REPOSITORY_URL:?Environment variable GIT_REPOSITORY_URL must be set}"
 : "${GIT_REPOSITORY_OWNER:?Environment variable GIT_REPOSITORY_OWNER must be set}"
 : "${GIT_REPOSITORY_NAME:?Environment variable GIT_REPOSITORY_NAME must be set}"
-: "${CHARTS_REPO:?Environment variable CHARTS_REPO must be set}"
 
 readonly REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
 
@@ -66,9 +64,10 @@ release_charts() {
 
 update_index() {
   git config user.name "$GIT_USERNAME"
+  git remote set-url origin https://github.com/honeycombio/helm-charts.git
 
   mkdir .cr-index
-  cr index --charts-repo "$CHARTS_REPO" --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --push
+  cr index --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --push
 }
 
 main

--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -64,7 +64,7 @@ release_charts() {
 
 update_index() {
   git config user.name "$GIT_USERNAME"
-  git remote set-url origin https://github.com/honeycombio/helm-charts.git
+  git remote set-url origin "https://github.com/$GIT_REPOSITORY_OWNER/$GIT_REPOSITORY_NAME.git"
 
   mkdir .cr-index
   cr index --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --push


### PR DESCRIPTION
## Which problem is this PR solving?

With the bump to chart releaser 1.5.0 we lost the ability to do `cr index` with an `ssh` git remote; the tool now requires us to use an `https` remote.  For the `v1.2.3-secure-tenancy` release I had to do the `cr index` step manually from my laptop. See and https://github.com/helm/chart-releaser/issues/124.

The PR solves this problem and also removes some deprecated flags and unused env vars.

## Short description of the changes

- set git remote to https url for `cr index` step.
- remove unused `--charts-repo` flag
- remove unused variables.

## How to verify that this has the expected result

I couldn't :/ but I'll try to do a honeycomb chart release once this is merged to test it.
