### PR TITLE
fix: Unset insteadOf in git config of release job

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -64,10 +64,11 @@ release_charts() {
 
 update_index() {
   git config user.name "$GIT_USERNAME"
-  git remote set-url origin "https://github.com/$GIT_REPOSITORY_OWNER/$GIT_REPOSITORY_NAME.git"
+  git config --global --unset url.ssh://git@github.com.insteadof
+  git remote add origin-https "https://github.com/$GIT_REPOSITORY_OWNER/$GIT_REPOSITORY_NAME.git"
 
   mkdir .cr-index
-  cr index --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --push
+  cr index --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --remote "origin-https" --push
 }
 
 main


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/helm-charts/issues/252

## Short description of the changes

- updates the release script to unset an `insteadOf` config in the global git config of the circleci job.

## How to verify that this has the expected result

Tested that the git remote is set properly.  Can't test the actual `cr index` command until the next release.
