### PR TITLE
feat: enable debug service by default

### DIFF
--- a/charts/refinery/ci/debug.yaml
+++ b/charts/refinery/ci/debug.yaml
@@ -1,0 +1,11 @@
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M
+  requests:
+    cpu: 100m
+    memory: 200M
+
+debug:
+  enabled: true
+  port: 6062

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -50,8 +50,6 @@ app.kubernetes.io/name: {{ include "refinery.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-
-
 {{/*
 Create a default fully qualified app name for the redis component.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -60,7 +58,6 @@ If release name contains chart name it will be used as a full name.
 {{- define "refinery.redis.fullname" -}}
 {{ include "refinery.fullname" . }}-redis
 {{- end }}
-
 
 {{/*
 Common labels for redis
@@ -82,13 +79,6 @@ app.kubernetes.io/name: {{ include "refinery.name" . }}-redis
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-
-
-
-
-
-
-
 {{/*
 Create the name of the service account to use
 */}}
@@ -98,4 +88,18 @@ Create the name of the service account to use
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Build config file for Refinery
+*/}}
+{{- define "refinery.config" -}}
+{{- $config := deepCopy .Values.config }}
+{{- if .Values.debug.enabled }}
+{{-   $debugServiceAddr := get $config "DebugServiceAddr" }}
+{{-   if not $debugServiceAddr }}
+{{-      $_ := set $config "DebugServiceAddr" (printf "localhost:%v" .Values.debug.port ) }}
+{{-   end }}
+{{- end }}
+{{- tpl (toYaml $config) . }}
 {{- end }}

--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -7,4 +7,4 @@ metadata:
   {{- include "refinery.labels" . | nindent 4 }}
 data:
   config.yaml: |
-{{- tpl (toYaml .Values.config) . | nindent 4 }}
+  {{- include "refinery.config" . | nindent 4 -}}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "refinery"
+            - "-d"
             - "-c"
             - "/etc/refinery/config.yaml"
             - "-r"
@@ -59,6 +60,9 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
+            - name: debug
+              containerPort: 6060
+              protocol: TCP
             - name: data
               containerPort: 8080
               protocol: TCP

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -50,19 +50,18 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "refinery"
-            - "-d"
             - "-c"
             - "/etc/refinery/config.yaml"
             - "-r"
             - "/etc/refinery/rules.yaml"
+            {{- if .Values.debug.enabled }}
+            - "-d"
+            {{- end }}
           {{- with .Values.environment }}
           env:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:
-            - name: debug
-              containerPort: 6060
-              protocol: TCP
             - name: data
               containerPort: 8080
               protocol: TCP
@@ -75,6 +74,11 @@ spec:
             {{- if eq .Values.config.Metrics "prometheus" }}
             - name: metrics
               containerPort: 9090
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.debug.enabled }}
+            - name: debug
+              containerPort: {{ .Values.debug.port }}
               protocol: TCP
             {{- end }}
           volumeMounts:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -604,3 +604,11 @@ secretProvider:
   create: false
   name: refinery
   spec: {}
+
+# When enabled, adds the -d flag to Refinery's arguments which enables the debug service.
+debug: 
+  enabled: true
+  # The port on which Refinery exposes the debug service.
+  # Only used if debug is enabled.
+  # This value will be used to set config.DebugServiceAddr if it is not already set.
+  port: 6061

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -611,4 +611,4 @@ debug:
   # The port on which Refinery exposes the debug service.
   # Only used if debug is enabled.
   # This value will be used to set config.DebugServiceAddr if it is not already set.
-  port: 6061
+  port: 6060


### PR DESCRIPTION
## Which problem is this PR solving?

pprof endpoints are not enabled by default and cannot easily be enabled since the argv isn't editable from the variables passed to the helm template by users.

## Short description of the changes

Enables the -d flag by default, which cause the container to listen on the :6060 debug service name.