### PR TITLE
fix: disable debug by default

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -607,7 +607,7 @@ secretProvider:
 
 # When enabled, adds the -d flag to Refinery's arguments which enables the debug service.
 debug: 
-  enabled: true
+  enabled: false
   # The port on which Refinery exposes the debug service.
   # Only used if debug is enabled.
   # This value will be used to set config.DebugServiceAddr if it is not already set.


### PR DESCRIPTION
## Which problem is this PR solving?
Accidentally set debug.enabled to true in https://github.com/honeycombio/helm-charts/pull/255

## Short description of the changes
- sets debug.enabled to false