### PR TITLE
fix: add git fetch to release step

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -66,6 +66,7 @@ update_index() {
   git config user.name "$GIT_USERNAME"
   git config --global --unset url.ssh://git@github.com.insteadof
   git remote add origin-https "https://github.com/$GIT_REPOSITORY_OWNER/$GIT_REPOSITORY_NAME.git"
+  git fetch --all
 
   mkdir .cr-index
   cr index --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --remote "origin-https" --push


### PR DESCRIPTION
## Which problem is this PR solving?

- Chart releases continue to fail and I keep having to finish them manually.  See https://github.com/honeycombio/helm-charts/pull/253 for history.

## Short description of the changes

- adds a `git fetch --all` command to ensure local git know all the branches.  Trying this based on https://github.com/JamesIves/github-pages-deploy-action/issues/74
