### PR TITLE
fix: [refinery] Add default GRPCServerParameters.ListenAddr

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -27,6 +27,9 @@ config:
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
 
+  GRPCServerParameters:
+    Enabled: true
+    ListenAddr: 0.0.0.0:4317
 
   PrometheusMetrics:
     # Enabled controls whether to expose Refinery metrics over the `PrometheusListenAddr` port.


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Fixes an issue where the 2.0.0 version of the chart did not correctly set `GRPCServerParameters.ListenAddr` default.  This meant that the 2.0.0 version of the chart does not enable otlp endpoint by default.

## Short description of the changes

- add back `GRPCServerParameters.ListenAddr` with the proper default value.

## How to verify that this has the expected result

Tested in local kind cluster.
