### PR TITLE
fix: Fix typo with `LiveReload`

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         {{- end }}
-        {{- if not .Values.LiveReloade }}
+        {{- if not .Values.LiveReload }}
         checksum/rules: {{ include (print $.Template.BasePath "/configmap-rules.yaml") . | sha256sum }}
         {{- end }}
       labels:


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes issue where the template was using `.Values.LiveReloade` instead of `.Values.Live.Reload`.

## Short description of the changes

- fix typo

## How to verify that this has the expected result

`helm template`
