### PR TITLE
feat: Add ability to specific extra refinery commands

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -122,6 +122,7 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `config` | Refinery Configuration | see [Refinery Configuration](#configuration) |
 | `debug.enabled` | whether or not the `-d` flag should be used in the Refinery arguments to enable the debug service  | `false` |
 | `debug.port` | the port on which the debug service will be exposed  | `6060` |
+| `extraCommandArgs` | List of extra string args to pass to refinery start command | `[]` |
 | `fullnameOverride` | String to fully override refinery.fullname template with a string | `nil` |
 | `grpcIngress.annotations` | gRPC Ingress annotations | `{}` |
 | `grpcIngress.enabled` | Enable ingress controller resource for gRPC traffic | `false` |

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -49,13 +49,16 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - "refinery"
-            - "-c"
-            - "/etc/refinery/config.yaml"
-            - "-r"
-            - "/etc/refinery/rules.yaml"
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
             {{- if .Values.debug.enabled }}
-            - "-d"
+            - -d
+            {{- end }}
+            {{- range .Values.extraCommandArgs }}
+            - {{ . }}
             {{- end }}
           {{- with .Values.environment }}
           env:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -89,6 +89,11 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Use this field to pass in extra arguments to the refinery command
+# such as --no-validate.  The chart already applies
+# -c and -r so those should not be included.
+extraCommandArgs: []
+
 imagePullSecrets: [ ]
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
## Which problem is this PR solving?

- Inability to specify any refinery commands, such as `--no-validate`

## Short description of the changes

- add new `extraCommandArgs` field.
- apply `extraCommandArgs` field to refinery command args.

## How to verify that this has the expected result

Manual test with local kind cluster
