### PR TITLE
fix: Update peer management to use redis

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -13,6 +13,7 @@ config:
     MinRefineryVersion: v2.0
 
   PeerManagement:
+    Type: redis
     # IdentifierInterfaceName specifies a network interface to use when finding a local hostname.
     # Due to the nature of DNS in Kubernetes, it is recommended to set this value to the 'eth0' interface name.
     # When configured the pod's IP will be used in the peer list


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- Refinery 2.0.0 incorrectly listed redis as the default peer management type when it is actually file.

## Short description of the changes

- updates the helm chart to use redis peer management by default

## How to verify that this has the expected result

Locally in kind cluster
