### PR TITLE
fix: Add back addrulereasontotrace

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -41,7 +41,6 @@ config:
 
   RefineryTelemetry:
     AddRuleReasonToTrace: true
-    AddSpanCountToRoot: false
 
   Debugging:
     AdditionalErrorFields:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -39,6 +39,14 @@ config:
     # Currently this helm chart expects port 9090 to be used for Refinery Prometheus metrics.
     ListenAddr: 0.0.0.0:9090
 
+  RefineryTelemetry:
+    AddRuleReasonToTrace: true
+    AddSpanCountToRoot: false
+
+  Debugging:
+    AdditionalErrorFields:
+      - trace.span_id
+
 # Refinery rules.
 # This section allows configuring Refinery rules.
 # The default value is the bare minimum Refinery requires in order to run.


### PR DESCRIPTION
## Which problem is this PR solving?

- 2.0.0 chart dropped AddRuleReasonToTrace

## Short description of the changes

- Add back appropriate RefineryTelemetry settings to match values used in 1.19.1

## How to verify that this has the expected result

Tested locally
