### PR TITLE
fix: Fix issue where default rule was always present unless explicitly disabled.

### DIFF
--- a/charts/refinery/ci/rules-values.yaml
+++ b/charts/refinery/ci/rules-values.yaml
@@ -1,0 +1,17 @@
+resources:
+  limits:
+    cpu: 100m
+    memory: 200M
+  requests:
+    cpu: 100m
+    memory: 200M
+
+rules:
+  RulesVersion: 2
+  Samplers:
+    __default__:
+      DeterministicSampler:
+        SampleRate: 100
+    test:
+      DeterministicSampler:
+        SampleRate: 1

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -112,3 +112,20 @@ Build config file for Refinery
 {{- define "refinery.DebugServiceAddr" -}}
 {{- printf "localhost:%v" .Values.debug.port }}
 {{- end}}
+
+{{/*
+Build rules file for Refinery
+*/}}
+{{- define "refinery.rules" -}}
+{{- $rules := deepCopy .Values.rules }}
+{{- $default := get $rules.Samplers "__default__" }}
+{{- if not $default }}
+{{-   $_ := set $rules.Samplers "__default__" (include "refinery.defaultRules" . | fromYaml) }}
+{{- end }} 
+{{- tpl (toYaml $rules) . }}
+{{- end }}
+
+{{- define "refinery.defaultRules" -}}
+DeterministicSampler:
+  SampleRate: 1
+{{- end}}

--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -9,6 +9,6 @@ metadata:
   {{- include "refinery.labels" . | nindent 4 }}
 data:
   rules.yaml: |
-{{- toYaml .Values.rules | nindent 4 }}
+  {{- include "refinery.rules" . | nindent 4 -}}
 
 {{ end }}

--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -93,15 +93,7 @@
           "type": "integer"
         },
         "Samplers": {
-          "type": "object",
-          "properties": {
-            "__default__": {
-              "type": "object"
-            }
-          },
-          "required": [
-            "__default__"
-          ]
+          "type": "object"
         }
       },
       "required": [

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -54,13 +54,14 @@ config:
 # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
 rules:
   RulesVersion: 2
-  Samplers:
+  Samplers: {}
     # The default sampler is used when no other sampler matches.
     # It is required to have a default sampler.
-    # The name consists of two underscores on either side of the word "default".
-    __default__:
-        DeterministicSampler:
-            SampleRate: 1
+    # If you do not supplie a default sampler the helm chart will inject
+    # the DeterministicSampler show below.
+    # __default__:
+    #     DeterministicSampler:
+    #         SampleRate: 1
 
 # RulesConfigMapName is used to override the default ConfigMap that defines the rules yaml.
 # When blank, refinery is configured using the a ConfigMap based on the rules below.

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -57,7 +57,7 @@ rules:
   Samplers: {}
     # The default sampler is used when no other sampler matches.
     # It is required to have a default sampler.
-    # If you do not supplie a default sampler the helm chart will inject
+    # If you do not supply a default sampler the helm chart will inject
     # the DeterministicSampler show below.
     # __default__:
     #     DeterministicSampler:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -58,7 +58,7 @@ rules:
     # The default sampler is used when no other sampler matches.
     # It is required to have a default sampler.
     # If you do not supply a default sampler the helm chart will inject
-    # the DeterministicSampler show below.
+    # the DeterministicSampler shown below.
     # __default__:
     #     DeterministicSampler:
     #         SampleRate: 1


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

- The include of a default in the values.yaml led to some confusion.  In order to override the default rule you had to explicitly set `.Values.rules.Samplers.__default__.DeterministicSampler: null`, which, while 100% correct in helm, is a little unintuative.

## Short description of the changes

- Updates the chart to only set a default rule if none is supplied by the user.  This ensures that Refinery always has a default rule, but won't mess with any users supplied configuration.

## How to verify that this has the expected result

Tested locally and added a new CI scenario
