### PR TITLE
fix: [refinery] Fix issue where Prometheus ports are not enabled when PrometheusMetrics is enabled

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.config.PrometheusMetrics.enabled }}
+        {{- if .Values.config.PrometheusMetrics.Enabled }}
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
         {{- end }}
@@ -74,7 +74,7 @@ spec:
             - name: peer
               containerPort: 8081
               protocol: TCP
-            {{- if .Values.config.PrometheusMetrics.enabled }}
+            {{- if .Values.config.PrometheusMetrics.Enabled }}
             - name: metrics
               containerPort: 9090
               protocol: TCP

--- a/charts/refinery/templates/service.yaml
+++ b/charts/refinery/templates/service.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       protocol: TCP
       name: grpc
-    {{- if .Values.config.PrometheusMetrics.enabled }}
+    {{- if .Values.config.PrometheusMetrics.Enabled }}
     - port: 9090
       targetPort: metrics
       protocol: TCP


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>

- Closes https://github.com/honeycombio/helm-charts/issues/273

## Short description of the changes

- Fixes typo where `enabled` was used instead of `Enabled`

## How to verify that this has the expected result

Tested with `helm template`
