### PR TITLE
patch/consistent-naming-ingressClassName

### DIFF
--- a/charts/refinery/templates/NOTES.txt
+++ b/charts/refinery/templates/NOTES.txt
@@ -1,2 +1,6 @@
+{{- if .Values.ingressClassName }}
+{{- fail "value for .Values.ingressClassName cannot be set" }}
+{{ end }}
+
 Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing
 within a few minutes at https://ui.honeycomb.io

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -27,8 +27,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingressClassName }}
+  ingressClassName: {{ .Values.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -27,8 +27,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingressClassName }}
-  ingressClassName: {{ .Values.ingressClassName }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/refinery/templates/ingress-grpc.yaml
+++ b/charts/refinery/templates/ingress-grpc.yaml
@@ -25,8 +25,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingressClassName }}
+  ingressClassName: {{ .Values.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.grpcIngress.hosts }}

--- a/charts/refinery/templates/ingress-grpc.yaml
+++ b/charts/refinery/templates/ingress-grpc.yaml
@@ -25,8 +25,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingressClassName }}
-  ingressClassName: {{ .Values.ingressClassName }}
+  {{- if .Values.grpcIngress.className }}
+  ingressClassName: {{ .Values.grpcIngress.className }}
   {{- end }}
   rules:
     {{- range .Values.grpcIngress.hosts }}

--- a/charts/refinery/templates/ingress.yaml
+++ b/charts/refinery/templates/ingress.yaml
@@ -25,8 +25,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingressClassName }}
-  ingressClassName: {{ .Values.ingressClassName }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -209,6 +209,7 @@ ingress:
   #  - secretName: refinery-tls
   #    hosts:
   #      - refinery.local
+  className: ""
 
 grpcIngress:
   enabled: false
@@ -223,6 +224,7 @@ grpcIngress:
   #  - secretName: refinery-tls
   #    hosts:
   #      - refinery.local
+  className: ""
 
 # Setup autoscaling for refinery
 # When autoscaling events occur, trace sharding will be recomputed. This will result in traces with missing spans being


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The `ingress-beta` and `ingress-grpc` Helm templates use one naming convention for an Ingress Class Name: `ingress.className`, whereas the `ingress` template uses a different convention: `ingressClassName`. 

The problem solved is to adopt a consistent naming convention. I've opted to the latter one, `ingressClassName`, as it's used in [Kubernetes example docs](https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource). 

Otherwise, users have unexpected inconsistent behavior when trying to specify the Ingress Class Name for the different ingresses. And, populating the `grpcIngress`'s Ingress Class Name currently would have to happen within the `ingress:` block in the values, which is unintuitive.

- Closes #N/A

## Short description of the changes

Changes the `ingress-beta.yaml` and `ingress-grpc.yaml` `ingress.className` to `ingressClassName` to be consistent with `ingress.yaml` and Kubernetes convention.

## How to verify that this has the expected result

Specify an `ingressClassName` in a values.yaml file and dry-run. No tests because it's a minimal change that seems to fit the "small and obvious" acceptance criteria laid out in the lifecycle-and-practices doc.