### PR TITLE
maint: Bump refinery version

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 2.1.2
-appVersion: 2.0.2
+appVersion: 2.1.0
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Bumps default refinery version to 2.1.0

- Closes https://github.com/honeycombio/helm-charts/issues/281
