### PR TITLE
fix: Enforce operator string length

### DIFF
--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -55,7 +55,7 @@ config:
 
 ## Configuring sampling rules
 
-Use [the Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/) to learn how to configure your sampling rules.
+Use [the Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/) to learn how to configure your sampling rules. When using the operators `>`, `>=` or `!=` make sure you denote they are strings by using single quotes (`''`).
 
 **NOTE**: Sampling rules are hot-reloaded and do not require pods to restart to take effect when upgrading via `helm upgrade` operations.
 

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -55,7 +55,7 @@ config:
 
 ## Configuring sampling rules
 
-Use [the Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/) to learn how to configure your sampling rules. When using the operators `>`, `>=` or `!=` make sure you denote they are strings by using single quotes (`''`).
+Use [the Refinery documentation](https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/) to learn how to configure your sampling rules. When using the operators `>`, `>=` or `!=` make sure you indicate that they are strings by enclosing them in single quotes. For example, use `'>='`.
 
 **NOTE**: Sampling rules are hot-reloaded and do not require pods to restart to take effect when upgrading via `helm upgrade` operations.
 

--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -93,7 +93,42 @@
           "type": "integer"
         },
         "Samplers": {
-          "type": "object"
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": "object",
+              "properties": {
+                "RulesBasedSampler": {
+                  "type": "object",
+                  "properties": {
+                    "Rules": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "Conditions": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "Operator": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "Operator"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "required": [

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -50,6 +50,7 @@ config:
 # This section allows configuring Refinery rules.
 # The default value is the bare minimum Refinery requires in order to run.
 # It is highly recommend to set your own rules.
+# When using the operators `>`, `>=` or `!=` make sure you denote they are strings by using single quotes ('').
 # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
 rules:
   RulesVersion: 2

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -50,7 +50,7 @@ config:
 # This section allows configuring Refinery rules.
 # The default value is the bare minimum Refinery requires in order to run.
 # It is highly recommend to set your own rules.
-# When using the operators `>`, `>=` or `!=` make sure you denote they are strings by using single quotes ('').
+# When using the operators `>`, `>=` or `!=`, indicate that they are strings by enclosing them in single quotes, like ('>=').
 # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
 rules:
   RulesVersion: 2


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>

- Closes https://github.com/honeycombio/helm-charts/issues/286

## Short description of the changes

- Updates the json schema file to enforce operator field to be required and have a length of at least 1
- Update the values.yaml and README with a warning to stringify certain operators

## How to verify that this has the expected result
Tested locally with `helm template`. If you provide `>`, or `!=` as an operator you now get 

```
Error: values don't meet the specifications of the schema(s) in the following chart(s):
refinery:
- rules.Samplers.testing.RulesBasedSampler.Rules.0.Conditions.0.Operator: String length must be greater than or equal to 1
```

Providing `>=` already caused an error.
