### PR TITLE
refinery/redis deployment: add ability to set inidividual pod annotations

### DIFF
--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -16,7 +16,8 @@ spec:
   {{- include "refinery.redis.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- $annotationsMerged := merge .Values.redis.podAnnotations .Values.podAnnotations }}
+      {{- with $annotationsMerged }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -163,6 +163,9 @@ redis:
   affinity: {}
   annotations: {}
 
+  # Pod annotations specific to installed Redis configuration. Requires redis.enabled to be true
+  podAnnotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
## Which problem is this PR solving?
Ability to set pod annotations which is useful when configuring scraping configuration, such as DataDog ([example](https://docs.datadoghq.com/integrations/redisdb/?tab=kubernetes)).

## How to verify that this has the expected result
This PR maintains backwards compatibility with existing annotations and merges with any optional values added as part of `values.redis.podAnnotations`. 
