### PR TITLE
maint: [network-agent] bump app version to v0.0.20-alpha

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hny-network-agent
 description: Honeycomb Network Agent
 version: 0.0.1-alpha
-appVersion: v0.0.19-alpha
+appVersion: v0.0.20-alpha
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent

--- a/charts/network-agent/README.md
+++ b/charts/network-agent/README.md
@@ -29,7 +29,6 @@ helm install hny-network-agent honeycomb/network-agent --set honeycomb.apiKey=$H
 
 **NOTE**: A secret to hold your Honeycomb API key is automatically created when the chart is installed and will be removed when the chart is uninstalled.
 
-
 The best practice is to manage your secret separately. You can set the name of an existing secret that will be used instead of creating one:
 
 ```console
@@ -42,7 +41,7 @@ The default key used to retrieve the API from the secret key is `apiKey`. You ca
 
 ### Using a values.yaml
 
-If you prefer to manage your helm charts by providing your own values.yaml, it is recommened to use an existing secret to avoid storing your Honeycomb API key as plain text.
+If you prefer to manage your helm charts by providing your own values.yaml, it is recommended to use an existing secret to avoid storing your Honeycomb API key as plain text.
 
 ```console
 export HONEYCOMB_API_KEY=YOUR_API_KEY
@@ -54,6 +53,6 @@ helm install hny-network-agent honeycomb/network-agent --values /path/to/values.
 
 The [values.yaml](./values.yaml) file contains information for all configuration options for this chart.
 
-The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource. 
+The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource.
 
 You can obtain your API Key by going to your Account profile page inside of your Honeycomb instance.


### PR DESCRIPTION
## Which problem is this PR solving?

new honeycomb network agent [v0.0.20-alpha](https://github.com/honeycombio/honeycomb-network-agent/releases/tag/v0.0.20-alpha) published

## Short description of the changes

- update appVersion to v0.0.20-alpha
- minor cleanup of readme
