### PR TITLE
rel: [network-agent] prepare first alpha release

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Honeycomb Network Agent Helm Chart Changelog
+
+## Honeycomb Network Agent v0.0.1-alpha
+
+Alpha release of Honeycomb Network Agent helm chart


### PR DESCRIPTION
## Which problem is this PR solving?

Lack of a published helm chart for the Honeycomb Network Agent.

- Closes https://github.com/honeycombio/honeycomb-network-agent/issues/235

## Short description of the changes

- Add changelog
- (no changes to version because this is the first one and it's already set to 0.0.1-alpha)
