### PR TITLE
rel: [network-agent] prep release 0.0.1

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Honeycomb Network Agent Helm Chart Changelog
 
-## Honeycomb Network Agent v0.0.1-alpha
+## Honeycomb Network Agent v0.0.1
 
-Alpha release of Honeycomb Network Agent helm chart
+Initial release of Honeycomb Network Agent helm chart
+
+- deploys [v0.0.20-alpha](https://github.com/honeycombio/honeycomb-network-agent/releases/tag/v0.0.20-alpha) of the Network Agent

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: hny-network-agent
 description: Honeycomb Network Agent
-version: 0.0.1-alpha
+version: 0.0.1
 appVersion: v0.0.20-alpha
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?

Actual first release of the helm chart for network agent.

## Short description of the changes

- update version to 0.0.1 instead of 0.0.1-alpha because the releasing process will not properly handle the alpha suffix in the tag.
- update changelog

## How to verify that this has the expected result

tag and release works 😅 