### PR TITLE
maint: [network-agent] fix up network-agent chart

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: hny-network-agent
+name: network-agent
 description: Honeycomb Network Agent
 version: 0.0.1
 appVersion: v0.0.20-alpha

--- a/charts/network-agent/README.md
+++ b/charts/network-agent/README.md
@@ -7,7 +7,7 @@ The Helm chart installs the [Honeycomb Network Agent](https://github.com/honeyco
 ```console
 helm repo add honeycomb https://honeycombio.github.io/helm-charts
 export HONEYCOMB_API_KEY=YOUR_API_KEY
-helm install hny-network-agent honeycomb/network-agent --set honeycomb.apiKey=$HONEYCOMB_API_KEY
+helm install network-agent honeycomb/network-agent --set honeycomb.apiKey=$HONEYCOMB_API_KEY
 ```
 
 ## Prerequisites
@@ -24,7 +24,7 @@ The easiest way to install the chart is by setting the Honeycomb API key directl
 
 ```console
 export HONEYCOMB_API_KEY=YOUR_API_KEY
-helm install hny-network-agent honeycomb/network-agent --set honeycomb.apiKey=$HONEYCOMB_API_KEY
+helm install network-agent honeycomb/network-agent --set honeycomb.apiKey=$HONEYCOMB_API_KEY
 ```
 
 **NOTE**: A secret to hold your Honeycomb API key is automatically created when the chart is installed and will be removed when the chart is uninstalled.
@@ -34,7 +34,7 @@ The best practice is to manage your secret separately. You can set the name of a
 ```console
 export HONEYCOMB_API_KEY=YOUR_API_KEY
 kubectl create secret generic hny-secrets --from-literal=apiKey=$HONEYCOMB_API_KEY
-helm install hny-network-agent honeycomb/network-agent --set honeycomb.existingSecret=hny-secrets
+helm install network-agent honeycomb/network-agent --set honeycomb.existingSecret=hny-secrets
 ```
 
 The default key used to retrieve the API from the secret key is `apiKey`. You can provide an alternative key by setting the `existingSecretKey` value.
@@ -46,7 +46,7 @@ If you prefer to manage your helm charts by providing your own values.yaml, it i
 ```console
 export HONEYCOMB_API_KEY=YOUR_API_KEY
 kubectl create secret generic hny-secrets --from-literal=apiKey=$HONEYCOMB_API_KEY
-helm install hny-network-agent honeycomb/network-agent --values /path/to/values.yaml
+helm install network-agent honeycomb/network-agent --values /path/to/values.yaml
 ```
 
 ## Configuration

--- a/charts/network-agent/templates/_helpers.tpl
+++ b/charts/network-agent/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "hny-network-agent.fullname" -}}
+{{- define "network-agent.fullname" -}}
 {{- if contains .Chart.Name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -14,26 +14,26 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "hny-network-agent.chart" -}}
+{{- define "network-agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "hny-network-agent.labels" -}}
-{{ include "hny-network-agent.selectorLabels" . }}
+{{- define "network-agent.labels" -}}
+{{ include "network-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-helm.sh/chart: {{ include "hny-network-agent.chart" . }}
+helm.sh/chart: {{ include "network-agent.chart" . }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "hny-network-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "hny-network-agent.fullname" . }}
+{{- define "network-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "network-agent.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/network-agent/templates/cluster_role.yaml
+++ b/charts/network-agent/templates/cluster_role.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
   labels:
-    {{- include "hny-network-agent.labels" . | nindent 4 }}
+    {{- include "network-agent.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["", "metrics.k8s.io","apps"]
     resources: ["*"]

--- a/charts/network-agent/templates/cluster_role_binding.yaml
+++ b/charts/network-agent/templates/cluster_role_binding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
   labels:
-    {{- include "hny-network-agent.labels" . | nindent 4 }}
+    {{- include "network-agent.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
 subjects:
   - kind: ServiceAccount
     namespace: {{ .Release.Namespace }}
-    name: {{ include "hny-network-agent.fullname" . }}
+    name: {{ include "network-agent.fullname" . }}

--- a/charts/network-agent/templates/daemonset.yaml
+++ b/charts/network-agent/templates/daemonset.yaml
@@ -40,6 +40,27 @@ spec:
             {{- with .Values.extraEnvVars }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
+            - name: AGENT_NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: AGENT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AGENT_SERVICE_ACCOUNT_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: AGENT_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           securityContext:
             capabilities:
               add:

--- a/charts/network-agent/templates/daemonset.yaml
+++ b/charts/network-agent/templates/daemonset.yaml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "hny-network-agent.labels" . | nindent 4 }}
+    {{- include "network-agent.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "hny-network-agent.selectorLabels" . | nindent 6 }}
+      {{- include "network-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "hny-network-agent.selectorLabels" . | nindent 8 }}
+        {{- include "network-agent.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "hny-network-agent.fullname" . }}
+      serviceAccountName: {{ include "network-agent.fullname" . }}
       hostNetwork: true
       containers:
         - name: hny-network-agent
@@ -28,7 +28,7 @@ spec:
                   name: {{ .Values.honeycomb.existingSecret }}
                   key: {{ .Values.honeycomb.existingSecretKey }}
                   {{- else }}
-                  name: {{ include "hny-network-agent.fullname" . }}
+                  name: {{ include "network-agent.fullname" . }}
                   key: apiKey
                   {{- end }}
             - name: HONEYCOMB_API_ENDPOINT

--- a/charts/network-agent/templates/secret.yaml
+++ b/charts/network-agent/templates/secret.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
   labels:
-    {{- include "hny-network-agent.labels" . | nindent 4 }}
+    {{- include "network-agent.labels" . | nindent 4 }}
 type: Opaque
 data:
   apiKey: {{ .Values.honeycomb.apiKey | b64enc | quote }}

--- a/charts/network-agent/templates/service_account.yaml
+++ b/charts/network-agent/templates/service_account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "hny-network-agent.fullname" . }}
+  name: {{ include "network-agent.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "hny-network-agent.labels" . | nindent 4 }}
+    {{- include "network-agent.labels" . | nindent 4 }}


### PR DESCRIPTION
## Which problem is this PR solving?

[Failed release](https://app.circleci.com/pipelines/github/honeycombio/helm-charts/819/workflows/01cf638e-3eef-4593-81f9-757850d900dc/jobs/431) because Chart name (hny-network-agent) didn't match directory name (network-agent). 

## Short description of the changes

- We opted for network-agent for chart name because honeycomb and/or honeycombio will be included when using the chart. The dataset names and container/pod names are intentionally kept as hny-network-agent to make it more easily distinguishable since these are things the user will see in a running k8s cluster. 
- Added the environment variables necessary for the use of k8s downward API in the agent, which adds k8s metadata to events so the agent knows things about itself.

## How to verify that this has the expected result

Events have all expected k8s metadata... and the release works 😅 😅 