### PR TITLE
feat: [network-agent] add resource limits

### DIFF
--- a/charts/network-agent/templates/daemonset.yaml
+++ b/charts/network-agent/templates/daemonset.yaml
@@ -37,9 +37,6 @@ spec:
               value: {{ .Values.honeycomb.dataset }}
             - name: HONEYCOMB_STATS_DATASET
               value: {{ .Values.honeycomb.statsDataset }}
-            {{- with .Values.extraEnvVars }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
             # https://kubernetes.io/docs/concepts/workloads/pods/downward-api/
             - name: AGENT_NODE_IP
               valueFrom:
@@ -61,6 +58,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
             capabilities:
               add:

--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -18,6 +18,11 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+resources: {}
+  # limits:
+  #   cpu: 750m
+  #   memory: 2Gi
+
 # Allows adding extra environment variables to the network agent daemonset.
 extraEnvVars:
   # - name: ENV_VAR


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/honeycomb-network-agent/issues/273

## Short description of the changes

- Add `resources` template to daemonset to allow end users to set resource limits
- Move `extraEnvVars` to bottom of daemonset
- Add `resources` to `values.yaml`

## How to verify that this has the expected result

Installing the helm chart with resource limits defined should set those limits as expected