### PR TITLE
maint: Add warning to NOTES.txt when no resouce limits are set

### DIFF
--- a/charts/network-agent/templates/NOTES.txt
+++ b/charts/network-agent/templates/NOTES.txt
@@ -20,3 +20,7 @@ You should see data flowing within a few minutes at https://ui.honeycomb.io.
 {{- if and (.Values.honeycomb.existingSecret) (not .Values.honeycomb.existingSecretKey) }}
 {{ fail "[ERROR] You must set a valid value for 'honeycomb.existingSecretKey' when using 'honeycomb.existingSecret' to provide your Honeycomb API key." }}
 {{- end }}
+
+{{- if not .Values.resources }}
+[WARNING] No resource limits or requests were set. Consider setter resource requests and limits for the Network Agent via the `resources` field.
+{{ end }}


### PR DESCRIPTION
## Which problem is this PR solving?
It is recommended to set resource limits when running the Network Agent.

## Short description of the changes
- Adds a waning to NOTES.txt when no resources are provided

## How to verify that this has the expected result
A warning is printed when no resources are provided when installing the chart. 