### PR TITLE
maint: Adds HTTP headers example to values.yaml

### DIFF
--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -27,6 +27,6 @@ resources: {}
 extraEnvVars:
   # - name: ENV_VAR
   #   value: value
-  # Configures the network agent to extract additional HTTP headers from request/response.
-  # - name: ADDITIONAL_HTTP_HEADERS  
+  # Configures the list of HTTP headers to be recorded from requests/responses.
+  # - name: HTTP_HEADERS  
   #   value: header1,header2

--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -27,3 +27,6 @@ resources: {}
 extraEnvVars:
   # - name: ENV_VAR
   #   value: value
+  # Configures the network agent to extract additional HTTP headers from request/response.
+  # - name: ADDITIONAL_HTTP_HEADERS  
+  #   value: header1,header2


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the example helm-chart to show how to configure additional HTTP headers to be extracted. 

- Implemented in https://github.com/honeycombio/honeycomb-network-agent/pull/277

## Short description of the changes
- Update example values.yaml with commented out config that shows how to set additional HTTP headers to extract

## How to verify that this has the expected result
The values.yaml show how to set additional headers to extract. 