### PR TITLE
maint: Bump agent version to v0.0.22-alpha

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
 version: 0.0.1
-appVersion: v0.0.20-alpha
+appVersion: v0.0.22-alpha
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent

--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -27,6 +27,12 @@ resources: {}
 extraEnvVars:
   # - name: ENV_VAR
   #   value: value
+  # Add extra attributes to all events
+  # - name: ADDITIONAL_ATTRIBUTES
+  #   value: "key1=value1,key2=value2"
+  # Disable including the request URL in events
+  # - name: INCLUDE_REQUEST_URL
+  #   value: "false"
   # Configures the list of HTTP headers to be recorded from requests/responses.
-  # - name: HTTP_HEADERS  
-  #   value: header1,header2
+  # - name: HTTP_HEADERS
+  #   value: "User-Agent,X-Custom-Header"


### PR DESCRIPTION
## Which problem is this PR solving?
Updates agent image version to [v0.0.22-alpha](https://github.com/honeycombio/honeycomb-network-agent/releases/tag/v0.0.22-alpha)

## Short description of the changes
- Update chart's appVersion to v0.0.22-alpha
- Updates additional env var examples

