### PR TITLE
rel: Prepare v0.0.2 of network agent chart

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Honeycomb Network Agent Helm Chart Changelog
 
+## Honeycomb Network Agent v0.0.2
+
+- feat: Add resource limits (#297) | @JamieDanielson
+- maint: Adds HTTP headers example to values.yaml (#299) | @MikeGoldsmith
+- maint: Add warning to NOTES.txt when no resouce limits are set (#298) | @MikeGoldsmith
+- maint: Bump agent version to [v0.0.22-alpha](https://github.com/honeycombio/honeycomb-network-agent/releases/tag/v0.0.22-alpha) | @MikeGoldsmith
+
 ## Honeycomb Network Agent v0.0.1
 
 Initial release of Honeycomb Network Agent helm chart

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.1
+version: 0.0.2
 appVersion: v0.0.22-alpha
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v0.0.22-alpha release of the network agent. 

## Short description of the changes
- Update chart version to v0.0.2
- Add changelog entry

Note:
This PR is based on the following PR and needs to wait for it to merge first:
- https://github.com/honeycombio/helm-charts/pull/300