### PR TITLE
maint: Update and document Network Agent cluster privileges

### DIFF
--- a/charts/network-agent/README.md
+++ b/charts/network-agent/README.md
@@ -59,10 +59,9 @@ You can obtain your API Key by going to your Account profile page inside of your
 
 ## Deployment Privileges
 
-The network agent uses the following Kubernetes cluster resources and permissions to enrich generated events with kubernetes metadata.
+The network agent requires the following permissions to enrich generated events with kubernetes metadata.
 
-Resources:
-- Pods, Services & Nodes
-
-Verbs:
-- Get, List & Watch
+```yaml
+-  apiGroups: ["", "metrics.k8s.io","apps"]
+    resources: ["nodes", "pods", "services"]
+    verbs: ["get","watch","list"]

--- a/charts/network-agent/README.md
+++ b/charts/network-agent/README.md
@@ -56,3 +56,13 @@ The [values.yaml](./values.yaml) file contains information for all configuration
 The only requirement is a Honeycomb API Key. This can be provided either by setting `honeycomb.apiKey` or by setting `honeycomb.existingSecret` to the name of an existing opaque secret resource.
 
 You can obtain your API Key by going to your Account profile page inside of your Honeycomb instance.
+
+## Deployment Privileges
+
+The network agent uses the following Kubernetes cluster resources and permissions to enrich generated events with kubernetes metadata.
+
+Resources:
+- Pods, Services & Nodes
+
+Verbs:
+- Get, List & Watch

--- a/charts/network-agent/templates/cluster_role.yaml
+++ b/charts/network-agent/templates/cluster_role.yaml
@@ -6,5 +6,5 @@ metadata:
     {{- include "network-agent.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["", "metrics.k8s.io","apps"]
-    resources: ["*"]
+    resources: ["nodes", "pods", "services"]
     verbs: ["get","watch","list"]


### PR DESCRIPTION
## Which problem is this PR solving?
Documents the cluster privileges to run the agent.

- Closes https://github.com/honeycombio/honeycomb-network-agent/issues/167

## Short description of the changes
- Upate list of resources to be more specific (nodes, pods & services) instead of `*` (all)

## How to verify that this has the expected result
The Network Agent's read me includes details on cluster privileges. 