### PR TITLE
rel: Prepare v0.0.3 of Honeycomb Network Agent

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb Network Agent Helm Chart Changelog
 
+## Honeycomb Network Agent v0.0.3
+
+- maint: Bump app to v0.0.23-alpha (#303) | @robbkidd
+- maint: Update and document Network Agent cluster privileges (#302) | @MikeGoldsmith
+
 ## Honeycomb Network Agent v0.0.2
 
 - feat: Add resource limits (#297) | @JamieDanielson

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.2
+version: 0.0.3
 appVersion: v0.0.23-alpha
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v0.0.3 release of the Honeycomb Network Agent chart.

## Short description of the changes
- Adds changelog entry
- Update chart version to v0.0.3

## How to verify that this has the expected result
New chart version is available.