### PR TITLE
maint: [network-agent] update network agent to 0.0.24-alpha

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
 version: 0.0.3
-appVersion: v0.0.23-alpha
+appVersion: v0.0.24-alpha
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent

--- a/charts/network-agent/README.md
+++ b/charts/network-agent/README.md
@@ -62,6 +62,7 @@ You can obtain your API Key by going to your Account profile page inside of your
 The network agent requires the following permissions to enrich generated events with kubernetes metadata.
 
 ```yaml
--  apiGroups: ["", "metrics.k8s.io","apps"]
+  - apiGroups: ["", "metrics.k8s.io","apps"]
     resources: ["nodes", "pods", "services"]
     verbs: ["get","watch","list"]
+```

--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -28,7 +28,7 @@ extraEnvVars:
   # - name: ENV_VAR
   #   value: value
   # Add extra attributes to all events
-  # - name: ADDITIONAL_ATTRIBUTES
+  # - name: OTEL_RESOURCE_ATTRIBUTES
   #   value: "key1=value1,key2=value2"
   # Disable including the request URL in events
   # - name: INCLUDE_REQUEST_URL
@@ -37,4 +37,7 @@ extraEnvVars:
   # Headers will appear as attributes with names normalized to lower- and snake-case.
   # For example: http.request.header.user_agent, http.response.header.x_custom_header
   # - name: HTTP_HEADERS
-  #   value: "User-Agent,X-Custom-Header"
+  #   value: "User-Agent,Traceparent,X-Custom-Header"
+  # Set to true if sending telemetry to an insecure endpoint
+  # - name: OTEL_EXPORTER_OTLP_INSECURE
+  #   value: "true"


### PR DESCRIPTION
## Short description of the changes

- update network agent appVersion to [0.0.24-alpha](https://github.com/honeycombio/honeycomb-network-agent/releases/tag/v0.0.24-alpha)
- update values.yaml for changes to environment variables now available with 24-alpha
- fix formatting in readme for privileges
