### PR TITLE
feat: add deploymentLabels to refinery chart

### DIFF
--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
+  {{- with .Values.deploymentLabels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.deploymentAnnotations }}
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -177,6 +177,8 @@ podLabels: {}
 
 podAnnotations: {}
 
+deploymentLabels: {}
+
 deploymentAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

In the same fashion as podLabels. Add the ability to configure custom deployment labels for the refinery helm chart.


## How to verify that this has the expected result

When running the following commands, the output should contain a `Deployment` resource for Refinery which contains the customer label `example.com/label: "true"`

```
echo 'deploymentLabels:                                                                                                                                                                                                                                                                                                                                                                                            
  example.com/label: "true"' > values.yml
helm template refinery charts/refinery --namespace=test --values=values.yml
```

