### PR TITLE
maint: Add linting to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,9 @@ jobs:
           command: |
             minikube start --driver=none --kubernetes-version=${K8S_VERSION}
       - run:
+          name: Lint charts
+          command: ct lint --target-branch main --config ./ct.yaml
+      - run:
           name: Test charts
           command: ct install --config ./ct.yaml
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
             minikube start --driver=none --kubernetes-version=${K8S_VERSION}
       - run:
           name: Lint charts
-          command: ct lint --target-branch main --config ./ct.yaml
+          command: ct lint --config ./ct.yaml
       - run:
           name: Test charts
           command: ct install --config ./ct.yaml

--- a/.circleci/install_testing_tools.sh
+++ b/.circleci/install_testing_tools.sh
@@ -4,6 +4,8 @@ set -o errexit
 
 readonly HELM_VERSION=3.5.2
 readonly CHART_TESTING_VERSION=3.7.1
+readonly YAMLLINT_VERSION=1.27.1
+readonly YAMALE_VERSION=3.0.4
 readonly MINIKUBE_VERSION=v1.27.1
 
 echo "Installing Helm..."
@@ -19,6 +21,8 @@ sudo mkdir -p "/usr/local/chart-testing-v$CHART_TESTING_VERSION"
 sudo tar -xzf "chart-testing_${CHART_TESTING_VERSION}_linux_amd64.tar.gz" -C "/usr/local/chart-testing-v$CHART_TESTING_VERSION"
 sudo ln -s "/usr/local/chart-testing-v$CHART_TESTING_VERSION/ct" /usr/local/bin/ct
 rm -f "chart-testing_${CHART_TESTING_VERSION}_linux_amd64.tar.gz"
+pip3 install "yamllint==${YAMLLINT_VERSION}"
+pip3 install "yamale==${YAMALE_VERSION}"
 
 echo "Installing Kubectl..."
 curl -Lo kubectl "https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl"

--- a/chart_schema.yaml
+++ b/chart_schema.yaml
@@ -1,0 +1,38 @@
+# from https://github.com/helm/chart-testing/blob/main/etc/chart_schema.yaml
+name: str()
+home: str(required=False)
+version: str()
+apiVersion: str()
+appVersion: any(str(), num(), required=False)
+description: str(required=False)
+keywords: list(str(), required=False)
+sources: list(str(), required=False)
+maintainers: list(include('maintainer'), required=False)
+dependencies: list(include('dependency'), required=False)
+icon: str(required=False)
+engine: str(required=False)
+condition: str(required=False)
+tags: str(required=False)
+deprecated: bool(required=False)
+kubeVersion: str(required=False)
+annotations: map(str(), str(), required=False)
+type: str(required=False)
+---
+maintainer:
+  name: str()
+  email: str(required=False)
+  url: str(required=False)
+---
+dependency:
+  name: str()
+  version: str()
+  repository: str(required=False)
+  condition: str(required=False)
+  tags: list(str(), required=False)
+  enabled: bool(required=False)
+  import-values: any(list(str()), list(include('import-value')), required=False)
+  alias: str(required=False)
+---
+import-value:
+  child: str()
+  parent: str()

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.8.0
+version: 1.8.1
 appVersion: 2.7.1
 keywords:
   - observability

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -13,11 +13,5 @@ sources:
   - https://github.com/honeycombio/honeycomb-kubernetes-agent
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
-  - name: fchikwekwe
-    email: faithchikwekwe@honeycomb.io
-  - name: kentquirk
-    email: kentquirk@honeycomb.io
-  - name: TylerHelmuth
-    email: tylerhelmuth@honeycomb.io
-  - name: VinozzZ
-    email: yingrongzhao@honeycomb.io
+  - name: Honeycomb
+    email: collection-team@honeycomb.io

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -13,5 +13,11 @@ sources:
   - https://github.com/honeycombio/honeycomb-kubernetes-agent
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
-  - name: puckpuck
-    email: pierre@honeycomb.io
+  - name: fchikwekwe
+    email: faithchikwekwe@honeycomb.io
+  - name: kentquirk
+    email: kentquirk@honeycomb.io
+  - name: TylerHelmuth
+    email: tylerhelmuth@honeycomb.io
+  - name: VinozzZ
+    email: yingrongzhao@honeycomb.io

--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.8.1
+version: 1.8.0
 appVersion: 2.7.1
 keywords:
   - observability

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.0.24-alpha
 home: https://honeycomb.io
 sources:

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.5
+version: 0.0.4
 appVersion: v0.0.24-alpha
 home: https://honeycomb.io
 sources:

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -7,3 +7,12 @@ home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
+maintainers:
+  - name: fchikwekwe
+    email: faithchikwekwe@honeycomb.io
+  - name: kentquirk
+    email: kentquirk@honeycomb.io
+  - name: TylerHelmuth
+    email: tylerhelmuth@honeycomb.io
+  - name: VinozzZ
+    email: yingrongzhao@honeycomb.io

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -8,11 +8,7 @@ sources:
   - https://github.com/honeycombio/honeycomb-network-agent
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
-  - name: fchikwekwe
-    email: faithchikwekwe@honeycomb.io
-  - name: kentquirk
-    email: kentquirk@honeycomb.io
-  - name: TylerHelmuth
-    email: tylerhelmuth@honeycomb.io
-  - name: VinozzZ
-    email: yingrongzhao@honeycomb.io
+  - name: Honeycomb
+    email: collection-team@honeycomb.io
+  - name: Honeycomb
+    email: telemetry-team@honeycomb.io

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -15,5 +15,11 @@ sources:
   - https://github.com/honeycombio/refinery
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
-  - name: puckpuck
-    email: pierre@honeycomb.io
+  - name: fchikwekwe
+    email: faithchikwekwe@honeycomb.io
+  - name: kentquirk
+    email: kentquirk@honeycomb.io
+  - name: TylerHelmuth
+    email: tylerhelmuth@honeycomb.io
+  - name: VinozzZ
+    email: yingrongzhao@honeycomb.io

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.1.0
 keywords:
   - refinery

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -15,11 +15,5 @@ sources:
   - https://github.com/honeycombio/refinery
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
-  - name: fchikwekwe
-    email: faithchikwekwe@honeycomb.io
-  - name: kentquirk
-    email: kentquirk@honeycomb.io
-  - name: TylerHelmuth
-    email: tylerhelmuth@honeycomb.io
-  - name: VinozzZ
-    email: yingrongzhao@honeycomb.io
+  - name: Honeycomb
+    email: collection-team@honeycomb.io

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.2.1
+version: 2.2.0
 appVersion: 2.1.0
 keywords:
   - refinery

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -103,7 +103,7 @@ image:
 # -c and -r so those should not be included.
 extraCommandArgs: []
 
-imagePullSecrets: [ ]
+imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
@@ -114,7 +114,7 @@ fullnameOverride: ""
 # - Redis Host: REFINERY_REDIS_HOST
 # - Redis Username: REFINERY_REDIS_USERNAME
 # - Redis Password: REFINERY_REDIS_PASSWORD
-environment: [ ]
+environment: []
   # - name: REFINERY_HONEYCOMB_API_KEY
   #   valueFrom:
   #     secretKeyRef:
@@ -123,13 +123,13 @@ environment: [ ]
 
 # Use to map additional volumes into the Refinery pods
 # Useful for volume-based secrets
-extraVolumeMounts: [ ]
+extraVolumeMounts: []
   # - name: honeycomb-secrets
   #   mountPath: "/mnt/secrets-store"
   #   readOnly: true
 
 # Use to map additional volumes into the Refinery pods
-extraVolumes: [ ]
+extraVolumes: []
   # - name: honeycomb-secrets
   #   csi:
   #     driver: secrets-store.csi.k8s.io

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,3 +5,4 @@ chart-dirs:
   - charts
 helm-extra-args: --timeout 120s
 exclude-deprecated: true
+check-version-increment: false

--- a/lintconf.yaml
+++ b/lintconf.yaml
@@ -1,0 +1,43 @@
+# from https://github.com/helm/chart-testing/blob/main/etc/lintconf.yaml
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  document-end: disable
+  document-start: disable           # No --- to start a file
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever      # - list indentation will handle both indentation and without
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable              # Lines can be any length
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Our charts dont have a linter, but that is required if we want to release on every commit (https://github.com/honeycombio/helm-charts/pull/309)

## Short description of the changes

- Adds linting to the CI
- Fixes existing lint issues

## How to verify that this has the expected result

CI
