### PR TITLE
maint: Bump hny network agent image to v0.0.25-alpha

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
 version: 0.0.4
-appVersion: v0.0.24-alpha
+appVersion: v0.0.25-alpha
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent


### PR DESCRIPTION
## Which problem is this PR solving?
Update the Honeycomb Network Agent image version to latest. 

## Short description of the changes
- Update app version in hny-network-agent chart to v0.0.25-alpha

## How to verify that this has the expected result
The netwok agent chart uses the latest image version. 