### PR TITLE
rel: Prepare v0.0.5 release of network agent

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Honeycomb Network Agent Helm Chart Changelog
 
+## Honeycomb Network Agent v0.05
+
+- maint: update network agent to v0.0.25-alpha (#311) | @MikeGoldsmith
+
 ## Honeycomb Network Agent v0.0.4
 
 - maint: update network agent to 0.0.24-alpha (#305) | @JamieDanielson

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
 version: 0.0.4
-appVersion: v0.0.24-alpha
+appVersion: v0.0.25-alpha
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.4
+version: 0.0.5
 appVersion: v0.0.25-alpha
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the next release of the Honeycomb Network Agent helm chart. 

## Short description of the changes
- Update chart version to 0.0.5
- Add changelog entry

## How to verify that this has the expected result
A new version of the network agent chart can be published. 