### PR TITLE
feat: Add support for custom pod annotations to network agent

### DIFF
--- a/charts/network-agent/templates/daemonset.yaml
+++ b/charts/network-agent/templates/daemonset.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "network-agent.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "network-agent.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/network-agent/values.yaml
+++ b/charts/network-agent/values.yaml
@@ -41,3 +41,6 @@ extraEnvVars:
   # Set to true if sending telemetry to an insecure endpoint
   # - name: OTEL_EXPORTER_OTLP_INSECURE
   #   value: "true"
+
+# Allows adding custom pod annotations to the network agent daemonset.
+podAnnotations: {}


### PR DESCRIPTION
## Which problem is this PR solving?
Adds support for custom pod annotations when deploying the network agent helm chart.

## Short description of the changes
- Add `podAnnotations` empty set in network agent's default values yaml
- Apply `podAnnotations` to the daemonset resource

## How to verify that this has the expected results
Custom pod annotations are applied to the network agent daemonset when set in the values yaml. 