### PR TITLE
rel: Prepare v0.0.6 release of network agent

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Honeycomb Network Agent Helm Chart Changelog
 
-## Honeycomb Network Agent v0.05
+## Honeycomb Network Agent v0.0.6
+
+- feat: Add support for custom pod annotations (#313) | @MikeGoldsmith
+
+## Honeycomb Network Agent v0.0.5
 
 - maint: update network agent to v0.0.25-alpha (#311) | @MikeGoldsmith
 

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.5
+version: 0.0.6
 appVersion: v0.0.25-alpha
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the v0.0.6 release of the Honeycomb network agent. 

## Short description of the changes
- Update chart version to 0.0.6
- Add changelog entry

## How to verify that this has the expected result
The next release of the network agent can be published. 