### PR TITLE
fix: update honeycomb templates to use release namespace

### DIFF
--- a/charts/honeycomb/templates/cluster-role.yaml
+++ b/charts/honeycomb/templates/cluster-role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "honeycomb.agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "honeycomb.agent.labels" . | nindent 4 }}
   annotations:

--- a/charts/honeycomb/templates/config.yaml
+++ b/charts/honeycomb/templates/config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "honeycomb.agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "honeycomb.agent.labels" . | nindent 4 }}
 data:

--- a/charts/honeycomb/templates/daemonset.yaml
+++ b/charts/honeycomb/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "honeycomb.agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "honeycomb.agent.labels" . | nindent 4 }}
 spec:

--- a/charts/honeycomb/templates/rbac.yaml
+++ b/charts/honeycomb/templates/rbac.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "honeycomb.agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "honeycomb.agent.labels" . | nindent 4 }}
 roleRef:

--- a/charts/honeycomb/templates/secret.yaml
+++ b/charts/honeycomb/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "honeycomb.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
   {{- include "honeycomb.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/honeycomb/templates/serviceaccount.yaml
+++ b/charts/honeycomb/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "honeycomb.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "honeycomb.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}


### PR DESCRIPTION
## Which problem is this PR solving?

This updates the honeycomb helm chart to use release namespace just like the collector helm chart did. 

Tested changes locally to ensure that namespace changes still work as intended. 
```
➜  kubectl config set-context --current --namespace=default    
Context "kind-kind" modified.
➜  helm template ./charts/opentelemetry-collector | grep -i namespace
WARNING: This chart is deprecated
  namespace: default
  namespace: default
  namespace: default
  namespace: default
  namespace: default
➜ kubectl config set-context --current --namespace=kube-public
Context "kind-kind" modified.
➜  helm template ./charts/opentelemetry-collector | grep -i namespace
WARNING: This chart is deprecated
  namespace: kube-public
  namespace: kube-public
  namespace: kube-public
  namespace: kube-public
  namespace: kube-public
```

- Closes #158
