### PR TITLE
maint: fix release note generation

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -103,7 +103,7 @@ package_chart() {
 
 release_charts() {
   echo 'Releasing charts...'
-  cr upload --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN"
+  cr upload --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --commit "$(git rev-parse HEAD)" --generate-release-notes
 }
 
 update_index() {

--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -103,7 +103,7 @@ package_chart() {
 
 release_charts() {
   echo 'Releasing charts...'
-  cr upload --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN" --generate-release-notes
+  cr upload --git-repo "$GIT_REPOSITORY_NAME" --owner "$GIT_REPOSITORY_OWNER" --token "$GITHUB_TOKEN"
 }
 
 update_index() {


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Passing the ` --generate-release-notes` broke things.  The fix is to ensure the upload command has the latest commit. The chart-releaser action solves this like so: https://github.com/helm/chart-releaser-action/blob/6203d709ca237fb26b724837f2c53716f244ee8c/cr.sh#L318C38-L318C64