### PR TITLE
maint: bump network-agent to v0.1.0-alpha

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.0.8
+version: 0.1.0
 appVersion: v0.1.0-beta
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?

Updating network-agent chart to install latest version, v0.1.0-beta.

## Short description of the changes

- bump the version of the network-agent installed by this chart
