### PR TITLE
maint: bump refinery to v2.2.0

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.3.0
-appVersion: 2.1.0
+version: 2.4.0
+appVersion: 2.2.0
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

This PR bumps the refinery app version to v2.2.0 and the chart version to v2.4.0

## Short description of the changes

release a new chart for refinery v2.2.0