### PR TITLE
rel(network-agent): Prepare chart version to v0.2.0

### DIFF
--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 **This changelog is now deprecated. See [Releases](https://github.com/honeycombio/helm-charts/releases) for the up-to-date list of changes.**
 
-## Honeycomb Network Agent v0.2.0
-
-- feat(network-agent): Add pod annotation for secret checksum (#324) | @MikeGoldsmith
-
-## Honeycomb Network Agent v0.1.0
-
-Published the v0.1.0 of the chart to reflect it's maturity. No other changes.
-
 ## Honeycomb Network Agent v0.0.6
 
 - feat: Add support for custom pod annotations (#313) | @MikeGoldsmith

--- a/charts/network-agent/CHANGELOG.md
+++ b/charts/network-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 **This changelog is now deprecated. See [Releases](https://github.com/honeycombio/helm-charts/releases) for the up-to-date list of changes.**
 
+## Honeycomb Network Agent v0.2.0
+
+- feat(network-agent): Add pod annotation for secret checksum (#324) | @MikeGoldsmith
+
+## Honeycomb Network Agent v0.1.0
+
+Published the v0.1.0 of the chart to reflect it's maturity. No other changes.
+
 ## Honeycomb Network Agent v0.0.6
 
 - feat: Add support for custom pod annotations (#313) | @MikeGoldsmith

--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.1.1
+version: 0.2.0
 appVersion: v0.1.0-beta
 home: https://honeycomb.io
 sources:


### PR DESCRIPTION
## Which problem is this PR solving?
Prepares the next version of the agent to be published.

## Short description of the changes
- Updates chart version to 0.2.0

## How to verify that this has the expected result
The next version of the chart can be published. 