### PR TITLE
maint(network-agent): Bump app version to 0.2.0-beta

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.2.0
-appVersion: v0.1.0-beta
+version: 0.3.0
+appVersion: v0.2.0-beta
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps the app image of the Network Agent to latest.

## Short description of the changes
- Update app image version to v0.2.0-beta
- Update chart version to 0.3.0

## How to verify that this has the expected result
New helm chart is published using latest agent image.