### PR TITLE
feat: Define redis resources

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.5.0
+version: 2.5.1
 appVersion: 2.3.0
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -38,6 +38,10 @@ spec:
             - name: redis
               containerPort: 6379
               protocol: TCP
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -153,6 +153,14 @@ redis:
     tag: 7.2
     pullPolicy: IfNotPresent
 
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 50Mi
+
   # Node selector specific to installed Redis configuration. Requires redis.enabled to be true
   nodeSelector: {}
 


### PR DESCRIPTION
## Which problem is this PR solving?

It should be possible to set redis resources from values.yaml

- Closes #331

## Short description of the changes

Allow setting redis resources from values.

## How to verify that this has the expected result

Configure resources in values.yaml under `redis.resources` and see that redis container resources are set accordingly.
