### PR TITLE
feat: Configure refinery labels and annotations for each resources

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.5.1
+version: 2.5.2
 appVersion: 2.3.0
 keywords:
   - refinery

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "refinery.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.extraLabels}}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -69,6 +72,9 @@ helm.sh/chart: {{ include "refinery.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.redis.extraLabels}}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/refinery/templates/configmap-config.yaml
+++ b/charts/refinery/templates/configmap-config.yaml
@@ -3,8 +3,15 @@ kind: ConfigMap
 metadata:
   name: {{ include "refinery.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4  }}
+  {{- end }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
+  {{- with .Values.configMap.labels }}
+    {{ toYaml . | nindent 4  }}
+  {{- end }}
 data:
   config.yaml: |
   {{- include "refinery.config" . | nindent 4 -}}

--- a/charts/refinery/templates/configmap-rules.yaml
+++ b/charts/refinery/templates/configmap-rules.yaml
@@ -5,8 +5,15 @@ kind: ConfigMap
 metadata:
   name: {{ include "refinery.fullname" . }}-rules
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.rulesConfigMap.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4  }}
+  {{- end }}
   labels:
   {{- include "refinery.labels" . | nindent 4 }}
+  {{- with .Values.rulesConfigMap.labels }}
+    {{ toYaml . | nindent 4  }}
+  {{- end }}
 data:
   rules.yaml: |
   {{- include "refinery.rules" . | nindent 4 -}}

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -17,8 +17,8 @@ spec:
   template:
     metadata:
       {{- /*
-        FIXME .Values.podAnnotations should not be used at all here.
-        Keeping it for backward compatibiltiy but should eventually be removed.
+       .Values.podAnnotations is used here to maintain backwards compatibility.
+       It should be removed eventually.
       */}}
       {{- if or .Values.podAnnotations .Values.redis.podAnnotations }}
       annotations:

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -6,9 +6,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.redis.labels" . | nindent 4 }}
-  {{- with .Values.redis.annotations }}
-    annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
 {{- with .Values.redis.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}
@@ -19,6 +16,10 @@ spec:
   {{- include "refinery.redis.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- /*
+        FIXME .Values.podAnnotations should not be used at all here.
+        Keeping it for backward compatibiltiy but should eventually be removed.
+      */}}
       {{- if or .Values.podAnnotations .Values.redis.podAnnotations }}
       annotations:
       {{- with .Values.podAnnotations }}

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{- include "refinery.redis.labels" . | nindent 4 }}
+  {{- with .Values.redis.annotations }}
+    annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.redis.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
 {{- end }}
@@ -16,12 +19,23 @@ spec:
   {{- include "refinery.redis.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- if or .Values.podAnnotations .Values.redis.podAnnotations }}
       annotations:
+      {{- with .Values.podAnnotations }}
       {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.podAnnotations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
     {{- include "refinery.redis.selectorLabels" . | nindent 8 }}
+    {{- with .Values.redis.extraLabels}}
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.redis.podLabels}}
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/refinery/templates/hpa.yaml
+++ b/charts/refinery/templates/hpa.yaml
@@ -4,8 +4,15 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "refinery.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.autoscaling.annotations}}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
+    {{- with .Values.autoscaling.labels}}
+    {{ toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -12,6 +12,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/refinery/templates/secretprovider.yaml
+++ b/charts/refinery/templates/secretprovider.yaml
@@ -4,6 +4,15 @@ kind: SecretProviderClass
 metadata:
   name: {{ .Values.secretProvider.name }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.secretProvider.annotations }}
+    annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "refinery.labels" . | nindent 4 }}
+    {{- with .Values.secretProvider.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   {{- with .Values.secretProvider.spec }}
   {{- toYaml . | nindent 4 }}

--- a/charts/refinery/templates/service-redis.yaml
+++ b/charts/refinery/templates/service-redis.yaml
@@ -4,13 +4,13 @@ kind: Service
 metadata:
   name: {{ include "refinery.redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.redis.annotations }}
+  {{- with .Values.redis.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     {{- include "refinery.redis.labels" . | nindent 4 }}
-    {{- with .Values.redis.labels }}
+    {{- with .Values.redis.service.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:

--- a/charts/refinery/templates/service-redis.yaml
+++ b/charts/refinery/templates/service-redis.yaml
@@ -4,8 +4,15 @@ kind: Service
 metadata:
   name: {{ include "refinery.redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.redis.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "refinery.redis.labels" . | nindent 4 }}
+    {{- with .Values.redis.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -193,10 +193,6 @@ redis:
   commonLabels: {}
     # my-label: some value
 
-  # Common labels applied to all Redis resources
-  commonLabels: {}
-    # my-label: some value
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -193,6 +193,11 @@ redis:
   commonLabels: {}
     # my-label: some value
 
+  # Redis service configuration
+  service:
+    labels: {}
+    annotations: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -72,6 +72,18 @@ RulesConfigMapName: ""
 # the Rules configmap changes
 LiveReload: true
 
+configMap:
+  labels: {}
+    # my-label: some value
+  annotations: {}
+    # my-annotation: some value
+
+rulesConfigMap:
+  labels: {}
+    # my-label: some value
+  annotations: {}
+    # my-annotation: some value
+
 ## Scaling Refinery ##
 #
 # Since Refinery is a stateful service we recommend provisioning refinery
@@ -137,6 +149,10 @@ extraVolumes: []
   #     volumeAttributes:
   #       secretProviderClass: "honeycomb-secrets"
 
+# Extra labels applied to all resources (except Redis resources).
+extraLabels: {}
+  # my-label: some value
+
 # Redis configuration
 redis:
 
@@ -170,6 +186,12 @@ redis:
   # Affinity specific to installed Redis configuration. Requires redis.enabled to be true
   affinity: {}
   annotations: {}
+  podAnnotations: {}
+  podLabels: {}
+
+  # Extra labels applied to all Redis resources
+  extraLabels: {}
+    # my-label: some value
 
 serviceAccount:
   # Specifies whether a service account should be created
@@ -248,6 +270,10 @@ autoscaling:
   behavior:
     scaleDown:
       selectPolicy: Disabled
+  labels: {}
+    # my-label: some value
+  annotations: {}
+    # my-annotation: some value
 
 nodeSelector: {}
 
@@ -278,6 +304,10 @@ affinity: {}
 secretProvider:
   create: false
   name: refinery
+  # Labels to add to the secret provider
+  labels: {}
+  # Annotations to add to the secret provider
+  annotations: {}
   spec: {}
 
 # When enabled, adds the -d flag to Refinery's arguments which enables the debug service.


### PR DESCRIPTION
## Which problem is this PR solving?

It would be nice to be able to define custom labels on all resources managed by this chart.

- Closes #334

## Short description of the changes

Allows defining a set of common labels to be applied to all resources.
It also enables managing labels and annotations on each resources independently.

## How to verify that this has the expected result
E.g. set `extraLabels: <some labels>`  or `configMap.labels: <labels>` and verify epxected labels have been added to corresponding resources.