### PR TITLE
feat: Add refinery common labels.

### DIFF
--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "refinery.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels}}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -69,6 +72,9 @@ helm.sh/chart: {{ include "refinery.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.redis.commonLabels}}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -22,6 +22,9 @@ spec:
       {{- end }}
       labels:
     {{- include "refinery.redis.selectorLabels" . | nindent 8 }}
+    {{- with .Values.redis.commonLabels}}
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       {{- with .Values.podLabels }}
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.redis.commonLabels}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -137,6 +137,10 @@ extraVolumes: []
   #     volumeAttributes:
   #       secretProviderClass: "honeycomb-secrets"
 
+# Common labels applied to all resources (except Redis resources).
+commonLabels: {}
+  # my-label: some value
+
 # Redis configuration
 redis:
 
@@ -170,6 +174,10 @@ redis:
   # Affinity specific to installed Redis configuration. Requires redis.enabled to be true
   affinity: {}
   annotations: {}
+
+  # Common labels applied to all Redis resources
+  commonLabels: {}
+    # my-label: some value
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
## Which problem is this PR solving?

It would be nice to be able to define custom labels on all resources managed by this chart.

- Contributes to #334

## Short description of the changes

Define values to be used as a set of common labels to be applied on all
refinery and redis resources

## How to verify that this has the expected result

Set `commonLabels: <some labels>` or `redis.commonLabels: <some labels>`  and verify epxected labels have been added to corresponding resources.


 