### PR TITLE
feat: Refinery lifecycle

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.6.3
+version: 2.6.4
 appVersion: 2.3.0
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -57,6 +57,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.redis.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -70,6 +70,10 @@ spec:
           env:
           {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: data
               containerPort: 8080

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -133,6 +133,16 @@ environment: []
   #       name: honeycomb
   #       key: api-key
 
+# Configure container lifecycle hooks.
+# This can be used to add a prestop hook to make rolling restarts more robust for instance.
+lifecycle: {}
+  # preStop:
+  #   exec:
+  #     command:
+  #       - "sh"
+  #       - "-c"
+  #       - "sleep 10"
+
 # Use to map additional volumes into the Refinery pods
 # Useful for volume-based secrets
 extraVolumeMounts: []
@@ -176,6 +186,16 @@ redis:
     # requests:
     #   cpu: 100m
     #   memory: 50Mi
+
+  # Configure container lifecycle hooks.
+  # This can be used to add a prestop hook to make rolling restarts more robust for instance.
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - "sh"
+    #       - "-c"
+    #       - "sleep 10"
 
   # Node selector specific to installed Redis configuration. Requires redis.enabled to be true
   nodeSelector: {}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -134,14 +134,7 @@ environment: []
   #       key: api-key
 
 # Configure container lifecycle hooks.
-# This can be used to add a prestop hook to make rolling restarts more robust for instance.
 lifecycle: {}
-  # preStop:
-  #   exec:
-  #     command:
-  #       - "sh"
-  #       - "-c"
-  #       - "sleep 10"
 
 # Use to map additional volumes into the Refinery pods
 # Useful for volume-based secrets

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -182,7 +182,7 @@ redis:
 
   # Configure container lifecycle hooks.
   lifecycle: {}
-  
+
   # Node selector specific to installed Redis configuration. Requires redis.enabled to be true
   nodeSelector: {}
 

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -188,15 +188,8 @@ redis:
     #   memory: 50Mi
 
   # Configure container lifecycle hooks.
-  # This can be used to add a prestop hook to make rolling restarts more robust for instance.
   lifecycle: {}
-    # preStop:
-    #   exec:
-    #     command:
-    #       - "sh"
-    #       - "-c"
-    #       - "sleep 10"
-
+  
   # Node selector specific to installed Redis configuration. Requires redis.enabled to be true
   nodeSelector: {}
 


### PR DESCRIPTION
## Which problem is this PR solving?

To make rolling update smoother, it is very common to add a sleep to containers preStop lifecycle to give Kubernetes some time to reconfigure the application's service endpoints.

- Closes #341

## Short description of the changes

Allow configuring each container lifecycle.

## How to verify that this has the expected result

Set values:
``` yaml
lifecycle: {}
    preStop:
      exec:
        command:
          - "sh"
          - "-c"
          - "sleep 10"
```
and check lifecycle has been configured as expected
