### PR TITLE
rel: Bump Network Agent to v0.2.1-beta

### DIFF
--- a/charts/network-agent/Chart.yaml
+++ b/charts/network-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: network-agent
 description: Honeycomb Network Agent
-version: 0.3.0
-appVersion: v0.2.0-beta
+version: 0.3.1
+appVersion: v0.2.1-beta
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/honeycomb-network-agent


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps Network Agent to latest version.

## Short description of the changes
- Update chart to 0.3.1
- Update appVersion to 0.2.1-beta

## How to verify that this has the expected result
New Network agent version can be installed via helm chart.