### PR TITLE
rel: Bump Kubernetes Agent to 2.7.2

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.8.2
-appVersion: 2.7.1
+version: 1.8.3
+appVersion: 2.7.2
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
## Which problem is this PR solving?
Bumps Kubernetes Agent to 2.7.2.

- Closes #343 

## Short description of the changes
- Update chart version to 1.8.3
- Update appVersion to 2.7.2

## How to verify that this has the expected result
New Kubernetes Agent is available to install via helm chart.