### PR TITLE
chore: bump refinery to 2.4

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.7.0
-appVersion: 2.3.0
+version: 2.8.0
+appVersion: 2.4.0
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION


## Which problem is this PR solving?

Bump refinery appVersion to 2.4 and bump chart version to 2.8.

