### PR TITLE
maint: Bump refinery version to v2.5.0

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.8.2
-appVersion: 2.4.3
+version: 2.9.0
+appVersion: 2.5.0
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Bumps default refinery version to v2.5.0

- Closes https://github.com/honeycombio/helm-charts/issues/353

## Short description of the changes

## How to verify that this has the expected result
