### PR TITLE
maint: Update ubuntu image in workflows to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,7 @@
 version: 2
 jobs:
   test-modified-charts:
-    machine:
-      image: ubuntu-2004:202201-02
+    runs-on: ubuntu-latest
     environment:
       K8S_VERSION: v1.23.13
     steps:
@@ -25,8 +24,7 @@ jobs:
 
 
   release-charts:
-    machine:
-      image: ubuntu-2004:202201-02
+    runs-on: ubuntu-latest
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,8 @@ jobs:
 
 
   release-charts:
-    runs-on: ubuntu-latest
+    machine:
+      image: ubuntu-2204:2024.01.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2
 jobs:
   test-modified-charts:
-    runs-on: ubuntu-latest
+    machine:
+      image: ubuntu-2204:2024.01.1
     environment:
       K8S_VERSION: v1.23.13
     steps:


### PR DESCRIPTION
## Which problem is this PR solving?
Older ubuntu images used in our workflows are being marked as deprecated. We need to update to newer ones.

## Short description of the changes
- Update workflows images to use `ubuntu-2204:2024.01.1` image

