### PR TITLE
rel: Prepare 3.0.0 pre-release

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.9.0
-appVersion: 2.5.0
+version: 3.0.0
+appVersion: 3.0.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 3.0.0
+version: 3.0.0-hnyinternal.0
 appVersion: 3.0.0
 keywords:
   - refinery

--- a/charts/refinery/ci/autoscale-values.yaml
+++ b/charts/refinery/ci/autoscale-values.yaml
@@ -8,3 +8,12 @@ resources:
 
 autoscaling:
   enabled: true
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/ci/debug.yaml
+++ b/charts/refinery/ci/debug.yaml
@@ -9,3 +9,12 @@ resources:
 debug:
   enabled: true
   port: 6062
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/ci/default-values.yaml
+++ b/charts/refinery/ci/default-values.yaml
@@ -5,3 +5,12 @@ resources:
   requests:
     cpu: 100m
     memory: 200M
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/ci/ingress-values.yaml
+++ b/charts/refinery/ci/ingress-values.yaml
@@ -11,3 +11,12 @@ ingress:
 
 grpcIngress:
   enabled: true
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/ci/pdb-values.yaml
+++ b/charts/refinery/ci/pdb-values.yaml
@@ -8,3 +8,12 @@ resources:
 
 podDisruptionBudget:
   enabled: true
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/ci/rules-values.yaml
+++ b/charts/refinery/ci/rules-values.yaml
@@ -15,3 +15,12 @@ rules:
     test:
       DeterministicSampler:
         SampleRate: 1
+
+redis:
+  resources:
+    limits:
+      cpu: 100m
+      memory: 200M
+    requests:
+      cpu: 100m
+      memory: 200M

--- a/charts/refinery/templates/NOTES.txt
+++ b/charts/refinery/templates/NOTES.txt
@@ -4,3 +4,7 @@ within a few minutes at https://ui.honeycomb.io
 {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
   {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot be both specified at the same time." }}
 {{- end }}
+
+{{- if .Values.ingress.className }}
+  {{- fail "ingress.className" has been removed. Use "ingress.ingressClassName" or "grpcIngress.ingressClassName" instead. }}
+{{- end }}

--- a/charts/refinery/templates/NOTES.txt
+++ b/charts/refinery/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{- if .Values.ingressClassName }}
-  {{- fail "value for .Values.ingressClassName cannot be set" }}
+  {{- fail "ingressClassName is no longer supported.  Use ingress.className or grpcIngress.className instead." }}
 {{- end }}
 
 Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing

--- a/charts/refinery/templates/NOTES.txt
+++ b/charts/refinery/templates/NOTES.txt
@@ -1,14 +1,10 @@
 {{- if .Values.ingressClassName }}
-{{- fail "value for .Values.ingressClassName cannot be set" }}
-{{ end }}
+  {{- fail "value for .Values.ingressClassName cannot be set" }}
+{{- end }}
 
 Honeycomb refinery is setup and configured to refine events that are sent through it. You should see data flowing
 within a few minutes at https://ui.honeycomb.io
 
 {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
   {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot be both specified at the same time." }}
-{{- end }}
-
-{{- if .Values.ingress.className }}
-  {{- fail "ingress.className" has been removed. Use "ingress.ingressClassName" or "grpcIngress.ingressClassName" instead. }}
 {{- end }}

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -1,6 +1,6 @@
-{{- if and .Values.redis.enabled (eq .Values.redis.mode "statefulset") }}
+{{- if and .Values.redis.enabled (eq .Values.redis.mode "deployment") }}
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: {{ include "refinery.redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -11,12 +11,6 @@ metadata:
 {{- end }}
 spec:
   replicas: 1
-  serviceName: {{ include "refinery.redis.fullname" . }}
-  {{- if .Values.redis.persistentVolumeClaimRetentionPolicy.enabled }}
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: {{ .Values.redis.persistentVolumeClaimRetentionPolicy.whenDeleted }}
-    whenScaled: {{ .Values.redis.persistentVolumeClaimRetentionPolicy.whenScaled }}
-  {{- end }}
   selector:
     matchLabels:
   {{- include "refinery.redis.selectorLabels" . | nindent 6 }}
@@ -67,9 +61,6 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - name: {{ .Values.redis.persistentVolumeClaim.name }}
-              mountPath: /data                
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -82,15 +73,4 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-  volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: {{ .Values.redis.persistentVolumeClaim.name }}
-      spec:
-        accessModes:
-          {{- toYaml .Values.redis.persistentVolumeClaim.accessModes | nindent 10}}
-        resources:
-          requests:
-            storage: {{ .Values.redis.persistentVolumeClaim.storageSize }}
-{{- end }}
+  {{- end }}

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -30,8 +30,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/refinery/templates/ingress-beta.yaml
+++ b/charts/refinery/templates/ingress-beta.yaml
@@ -30,8 +30,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}

--- a/charts/refinery/templates/ingress-grpc.yaml
+++ b/charts/refinery/templates/ingress-grpc.yaml
@@ -25,8 +25,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.grpcIngress.ingressClassName }}
+  ingressClassName: {{ .Values.grpcIngress.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.grpcIngress.hosts }}

--- a/charts/refinery/templates/statefulset-redis.yaml
+++ b/charts/refinery/templates/statefulset-redis.yaml
@@ -67,10 +67,9 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.redis.volumeMounts }}
           volumeMounts:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}          
+            - name: {{ .Values.redis.persistentVolumeClaim.name }}
+              mountPath: /data                
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -83,8 +82,15 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-  {{- with .Values.redis.volumeClaimTemplates }}
   volumeClaimTemplates:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: {{ .Values.redis.persistentVolumeClaim.name }}
+      spec:
+        accessModes:
+          {{- toYaml .Values.redis.persistentVolumeClaim.accessModes | nindent 10}}
+        resources:
+          requests:
+            storage: {{ .Values.redis.persistentVolumeClaim.storageSize }}
 {{- end }}

--- a/charts/refinery/templates/statefulset-redis.yaml
+++ b/charts/refinery/templates/statefulset-redis.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.redis.enabled }}
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "refinery.redis.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -11,6 +11,12 @@ metadata:
 {{- end }}
 spec:
   replicas: 1
+  serviceName: {{ include "refinery.redis.fullname" . }}
+  {{- if .Values.redis.persistentVolumeClaimRetentionPolicy.enabled }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .Values.redis.persistentVolumeClaimRetentionPolicy.whenDeleted }}
+    whenScaled: {{ .Values.redis.persistentVolumeClaimRetentionPolicy.whenScaled }}
+  {{- end }}
   selector:
     matchLabels:
   {{- include "refinery.redis.selectorLabels" . | nindent 6 }}
@@ -61,6 +67,10 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.redis.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}          
       {{- with .Values.redis.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}
@@ -73,4 +83,8 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- with .Values.redis.volumeClaimTemplates }}
+  volumeClaimTemplates:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -85,6 +85,9 @@
         },
         "CentralStore": {
           "type": "object"
+        },
+        "OTelTracing": {
+          "type": "object"
         }
       }
     },

--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -82,6 +82,9 @@
         },
         "StressRelief": {
           "type": "object"
+        },
+        "CentralStore": {
+          "type": "object"
         }
       }
     },

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -29,12 +29,8 @@ config:
 
   Collection:
     # AvailableMemory is the amount of system memory available to the Refinery process.
-    MaxAlloc: '{{ .Values.resources.limits.memory }}'
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
-    # TraceFetcherConcurrency: 2
-    # ProcessTracesBatchSize: 1000
-    # DeciderBatchSize: 1000
 
   GRPCServerParameters:
     Enabled: true
@@ -55,14 +51,6 @@ config:
     AdditionalErrorFields:
       - trace.span_id
 
-  OTelMetrics:
-    Enabled: true
-    ReportingInterval: 1s
-
-  OTelTracing:
-    Type: otel
-    Dataset: refinery_traces
-
 # Refinery rules.
 # This section allows configuring Refinery rules.
 # The default value is the bare minimum Refinery requires in order to run.
@@ -71,10 +59,7 @@ config:
 # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
 rules:
   RulesVersion: 2
-  Samplers:
-    __default__:
-        DeterministicSampler:
-            SampleRate: 2
+  Samplers: {}
     # The default sampler is used when no other sampler matches.
     # It is required to have a default sampler.
     # If you do not supply a default sampler the helm chart will inject
@@ -82,35 +67,6 @@ rules:
     # __default__:
     #     DeterministicSampler:
     #         SampleRate: 1
-    test:
-      RulesBasedSampler:
-        Rules:
-          - Name: keep a quarter of clock/other
-            Conditions:
-              - Fields:
-                  - url
-                  - http.target
-                Operator: matches
-                Value: '/c\w+/other'
-            SampleRate: 4
-          - Name: keep half of anything mentioning clocks
-            Conditions:
-              - Field: url
-                Operator: matches
-                Value: '/clock'
-            SampleRate: 2
-          - Name: keep a third of drawer/anything
-            Conditions:
-              - Field: url
-                Operator: matches
-                Value: '^https://example.com/drawer.*$'
-            SampleRate: 3
-          - Name: drop really big traces
-            Conditions:
-              - Field: ?.NUM_DESCENDANTS
-                Operator: '>'
-                Value: 1000
-            Drop: true
 
 # RulesConfigMapName is used to override the default ConfigMap that defines the rules yaml.
 # When blank, refinery is configured using the a ConfigMap based on the rules below.
@@ -150,11 +106,11 @@ resources:
     # This value is used by default for config.Collection.AvailableMemory
     memory: 4Gi
   requests:
-    cpu: 500m
+    cpu: 2
     memory: 500Mi
 
 image:
-  repository: honeycombio/refinery
+  repository: tylerhelmuthhc/refinery
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -19,20 +19,17 @@ config:
   RedisPeerManagement:
     # Host is the host and port of the Redis instance to use for peer cluster membership management.
     Host: '{{include "refinery.redis.fullname" .}}:6379'
-    MaxIdle: 30
+    MaxIdle: 100
     MaxActive: 100
 
   Collection:
     # AvailableMemory is the amount of system memory available to the Refinery process.
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
-    SenderBatchSize: 1000
-    DeciderBatchSize: 1000
 
   GRPCServerParameters:
     Enabled: true
     ListenAddr: 0.0.0.0:4317
-    MaxConnectionAge: 10s
 
   PrometheusMetrics:
     # Enabled controls whether to expose Refinery metrics over the `PrometheusListenAddr` port.
@@ -96,7 +93,7 @@ rulesConfigMap:
 # per your anticipated peak load. Refinery now performs better with many smaller
 # instances instead of a few big instances.
 # replicaCount is ignored if autoscaling is enabled
-replicaCount: 6
+replicaCount: 3
 
 resources:
   limits:
@@ -104,7 +101,7 @@ resources:
     # This value is used by default for config.Collection.AvailableMemory
     memory: 2Gi
   requests:
-    cpu: 1
+    cpu: 2
     memory: 500Mi
 
 image:
@@ -179,7 +176,7 @@ redis:
       cpu: 2
       memory: 2Gi
     requests:
-      cpu: 100m
+      cpu: 1
       memory: 500Mi
 
   # Configure container lifecycle hooks.

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -161,17 +161,15 @@ commonLabels: {}
 
 # Redis configuration
 redis:
-  # To install a simple single pod Redis deployment set this to true.
+  # To install a simple single pod Redis statefulset set this to true.
   # If false, you must specify a value for config.RedisPeerManagement.Host.
   # For production, it is recommended to set this to false and provide
-  # a highly available Redis configuration using config.RedisPeerManagement.Host.
+  # an existing highly available Redis instance via using config.RedisPeerManagement.Host.
   enabled: true
 
-  # If redis.enabled is true, this the image that will be used to create
-  # the Redis deployment
   image:
     repository: redis
-    tag: 7.4
+    tag: 7.2
     pullPolicy: IfNotPresent
 
   resources:
@@ -205,6 +203,27 @@ redis:
   service:
     labels: {}
     annotations: {}
+
+  volumeMounts:
+    - name: refinery-redis-data
+      mountPath: /data
+
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: refinery-redis-data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"
+
+  persistentVolumeClaimRetentionPolicy:
+    enabled: false
+    whenDeleted: Retain
+    whenScaled: Retain
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -14,6 +14,7 @@ config:
 
   CentralStore:
     Type: redis
+    SpanChannelSize: 100_000
 
   PeerManagement:
     Type: redis

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -14,7 +14,7 @@ config:
 
   CentralStore:
     Type: redis
-    SpanChannelSize: 100_000
+    SpanChannelSize: 1_000
 
   PeerManagement:
     Type: redis
@@ -29,12 +29,17 @@ config:
 
   Collection:
     # AvailableMemory is the amount of system memory available to the Refinery process.
+    MaxAlloc: '{{ .Values.resources.limits.memory }}'
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
+    # TraceFetcherConcurrency: 2
+    # ProcessTracesBatchSize: 1000
+    # DeciderBatchSize: 1000
 
   GRPCServerParameters:
     Enabled: true
     ListenAddr: 0.0.0.0:4317
+    MaxConnectionAge: 10s
 
   PrometheusMetrics:
     # Enabled controls whether to expose Refinery metrics over the `PrometheusListenAddr` port.
@@ -50,6 +55,14 @@ config:
     AdditionalErrorFields:
       - trace.span_id
 
+  OTelMetrics:
+    Enabled: true
+    ReportingInterval: 1s
+
+  OTelTracing:
+    Type: otel
+    Dataset: refinery_traces
+
 # Refinery rules.
 # This section allows configuring Refinery rules.
 # The default value is the bare minimum Refinery requires in order to run.
@@ -58,7 +71,10 @@ config:
 # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
 rules:
   RulesVersion: 2
-  Samplers: {}
+  Samplers:
+    __default__:
+        DeterministicSampler:
+            SampleRate: 2
     # The default sampler is used when no other sampler matches.
     # It is required to have a default sampler.
     # If you do not supply a default sampler the helm chart will inject
@@ -66,6 +82,35 @@ rules:
     # __default__:
     #     DeterministicSampler:
     #         SampleRate: 1
+    test:
+      RulesBasedSampler:
+        Rules:
+          - Name: keep a quarter of clock/other
+            Conditions:
+              - Fields:
+                  - url
+                  - http.target
+                Operator: matches
+                Value: '/c\w+/other'
+            SampleRate: 4
+          - Name: keep half of anything mentioning clocks
+            Conditions:
+              - Field: url
+                Operator: matches
+                Value: '/clock'
+            SampleRate: 2
+          - Name: keep a third of drawer/anything
+            Conditions:
+              - Field: url
+                Operator: matches
+                Value: '^https://example.com/drawer.*$'
+            SampleRate: 3
+          - Name: drop really big traces
+            Conditions:
+              - Field: ?.NUM_DESCENDANTS
+                Operator: '>'
+                Value: 1000
+            Drop: true
 
 # RulesConfigMapName is used to override the default ConfigMap that defines the rules yaml.
 # When blank, refinery is configured using the a ConfigMap based on the rules below.
@@ -101,9 +146,9 @@ replicaCount: 3
 
 resources:
   limits:
-    cpu: 2000m
+    cpu: 10
     # This value is used by default for config.Collection.AvailableMemory
-    memory: 2Gi
+    memory: 4Gi
   requests:
     cpu: 500m
     memory: 500Mi
@@ -168,6 +213,8 @@ redis:
   # an existing highly available Redis instance via using config.RedisPeerManagement.Host.
   enabled: true
 
+  mode: deployment
+
   image:
     repository: redis
     tag: 7.2
@@ -175,8 +222,8 @@ redis:
 
   resources:
     limits:
-      cpu: 1
-      memory: 1Gi
+      cpu: 2
+      memory: 2Gi
     requests:
       cpu: 100m
       memory: 500Mi
@@ -205,16 +252,18 @@ redis:
     labels: {}
     annotations: {}
 
+  # Only used with redis.mode=statefulset
   persistentVolumeClaim:
     name: refinery-redis-data
     accessModes:
       - "ReadWriteOnce"
     storageSize: "8Gi"
 
+  # Only used with redis.mode=statefulset
   persistentVolumeClaimRetentionPolicy:
-    enabled: false
-    whenDeleted: Retain
-    whenScaled: Retain
+    enabled: true
+    whenDeleted: Delete
+    whenScaled: Delete
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -251,7 +251,6 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  # ingressClassName: nginx
   hosts:
     - host: refinery.local
       path: /
@@ -270,7 +269,6 @@ grpcIngress:
   hosts:
     - host: refinery.local
       path: /
-  # ingressClassName: nginx
   tls: []
   #  - secretName: refinery-tls
   #    hosts:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -94,7 +94,7 @@ rulesConfigMap:
 #
 # Use replicaCount and resource limits to set the size of your Refinery cluster
 # per your anticipated peak load. Refinery now performs better with many smaller
-# instances instead of a few big instances. 
+# instances instead of a few big instances.
 # replicaCount is ignored if autoscaling is enabled
 replicaCount: 6
 

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -161,11 +161,10 @@ commonLabels: {}
 
 # Redis configuration
 redis:
-
   # To install a simple single pod Redis deployment set this to true.
-  # If false, you must specify a value for existingHost
+  # If false, you must specify a value for config.RedisPeerManagement.Host.
   # For production, it is recommended to set this to false and provide
-  # a highly available Redis configuration using redis.existingHost
+  # a highly available Redis configuration using config.RedisPeerManagement.Host.
   enabled: true
 
   # If redis.enabled is true, this the image that will be used to create
@@ -175,13 +174,13 @@ redis:
     tag: 7.4
     pullPolicy: IfNotPresent
 
-  resources: {}
-    # limits:
-    #   cpu: 500m
-    #   memory: 128Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 50Mi
+  resources:
+    limits:
+      cpu: 1
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 500Mi
 
   # Configure container lifecycle hooks.
   lifecycle: {}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -9,7 +9,7 @@
 # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
 config:
   General:
-    ConfigurationVersion: 3
+    ConfigurationVersion: 2
     MinRefineryVersion: v3.0
 
   CentralStore:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -9,8 +9,11 @@
 # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
 config:
   General:
-    ConfigurationVersion: 2
-    MinRefineryVersion: v2.0
+    ConfigurationVersion: 3
+    MinRefineryVersion: v3.0
+
+  CentralStore:
+    Type: redis
 
   PeerManagement:
     Type: redis
@@ -169,7 +172,7 @@ redis:
   # the Redis deployment
   image:
     repository: redis
-    tag: 7.2
+    tag: 7.4
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -249,6 +252,7 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
+  # ingressClassName: nginx
   hosts:
     - host: refinery.local
       path: /
@@ -266,15 +270,13 @@ grpcIngress:
   hosts:
     - host: refinery.local
       path: /
+  # ingressClassName: nginx
   tls: []
   #  - secretName: refinery-tls
   #    hosts:
   #      - refinery.local
 
 # Setup autoscaling for refinery
-# When autoscaling events occur, trace sharding will be recomputed. This will result in traces with missing spans being
-# sent to Honeycomb, for a small period of time (approximately config.Traces.TraceTimeout * 2).
-# Because of this, scaleDown is disabled by default to avoid unnecessary broken traces should traffic go up and down rapidly.
 autoscaling:
   enabled: false
   minReplicas: 3

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -204,21 +204,11 @@ redis:
     labels: {}
     annotations: {}
 
-  volumeMounts:
-    - name: refinery-redis-data
-      mountPath: /data
-
-  volumeClaimTemplates:
-    - apiVersion: v1
-      kind: PersistentVolumeClaim
-      metadata:
-        name: refinery-redis-data
-      spec:
-        accessModes:
-          - "ReadWriteOnce"
-        resources:
-          requests:
-            storage: "8Gi"
+  persistentVolumeClaim:
+    name: refinery-redis-data
+    accessModes:
+      - "ReadWriteOnce"
+    storageSize: "8Gi"
 
   persistentVolumeClaimRetentionPolicy:
     enabled: false

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -14,23 +14,20 @@ config:
 
   CentralStore:
     Type: redis
-    SpanChannelSize: 1_000
-
-  PeerManagement:
-    Type: redis
-    # IdentifierInterfaceName specifies a network interface to use when finding a local hostname.
-    # Due to the nature of DNS in Kubernetes, it is recommended to set this value to the 'eth0' interface name.
-    # When configured the pod's IP will be used in the peer list
-    IdentifierInterfaceName: eth0
+    SpanChannelSize: 10_000
 
   RedisPeerManagement:
     # Host is the host and port of the Redis instance to use for peer cluster membership management.
     Host: '{{include "refinery.redis.fullname" .}}:6379'
+    MaxIdle: 30
+    MaxActive: 100
 
   Collection:
     # AvailableMemory is the amount of system memory available to the Refinery process.
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
+    SenderBatchSize: 1000
+    DeciderBatchSize: 1000
 
   GRPCServerParameters:
     Enabled: true
@@ -91,22 +88,23 @@ rulesConfigMap:
 
 ## Scaling Refinery ##
 #
-# Since Refinery is a stateful service we recommend provisioning refinery
+# If you are not using autoscaling we recommend provisioning refinery
 # for your anticipated peak load and using Stress Relief to minimize impact
 # from changes in cluster membership.
 #
 # Use replicaCount and resource limits to set the size of your Refinery cluster
-# per your anticipated peak load.
+# per your anticipated peak load. Refinery now performs better with many smaller
+# instances instead of a few big instances. 
 # replicaCount is ignored if autoscaling is enabled
-replicaCount: 3
+replicaCount: 6
 
 resources:
   limits:
-    cpu: 10
+    cpu: 4
     # This value is used by default for config.Collection.AvailableMemory
-    memory: 4Gi
+    memory: 2Gi
   requests:
-    cpu: 2
+    cpu: 1
     memory: 500Mi
 
 image:


### PR DESCRIPTION
Prepares an "internal" release of the chart for us to test Refinery 3.0.0.  

> :warning: We do not recommend any customer use this version of the chart and we do not support it.

Changes:
- The commits from https://github.com/honeycombio/helm-charts/pull/278 (thanks @zenon-was-here!)
- Updated default refinery configuration
- Updated resource values
- A new Statefulset Redis deployment option