### PR TITLE
fix(refinery): point to honeycombio namespace for image

### DIFF
--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -105,7 +105,7 @@ resources:
     memory: 500Mi
 
 image:
-  repository: tylerhelmuthhc/refinery
+  repository: honeycombio/refinery
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

<please describe the issue>

- Closes #<enter issue here>

## Short description of the changes

Point to the correct repository for official refinery images

## How to verify that this has the expected result
