### PR TITLE
[refinery] Make ShutdownDelay based on terminationGracePeriodSeconds

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 3.0.0-hnyinternal.1
+version: 3.0.0-hnyinternal.2
 appVersion: 3.0.0
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -23,6 +23,7 @@ config:
     MaxActive: 100
 
   Collection:
+    ShutdownDelay: '{{ sub .Values.terminationGracePeriodSeconds 5 }}s'
     # AvailableMemory is the amount of system memory available to the Refinery process.
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
@@ -314,6 +315,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+terminationGracePeriodSeconds: 35
 
 # PodDisruptionBudget:
 #


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery 3 attempts to preserve data on shutdown, and has a configurable ShutdownDelay field where it tries to process remaining work while shutting down. In k8s we need this config option to be inline with `terminationGracePeriodSeconds` to ensure k8s doesn't kill pods early.

## Short description of the changes

- added terminationGracePeriodSeconds configuration option in values.yaml
- set `ShutdownDelay` to be `terminationGracePeriodSeconds - 5` seconds by default.  Users can override this value in their values.yaml

## How to verify that this has the expected result

Tested locally in kind.
