### PR TITLE
rel(refinery): bump default refinery version to 2.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ jobs:
             minikube start --driver=none --kubernetes-version=${K8S_VERSION}
       - run:
           name: Lint charts
-          command: ct lint --config ./ct.yaml
+          command: ct lint --config ./ct.yaml --target-branch refinery-2.X-work-branch
       - run:
           name: Test charts
-          command: ct install --config ./ct.yaml
+          command: ct install --config ./ct.yaml --target-branch refinery-2.X-work-branch
 
 
   release-charts:

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.9.0
-appVersion: 2.5.0
+version: 2.9.1
+appVersion: 2.5.1
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

For the 2.X version of the refinery helm chart, updates the default refinery version to be 2.5.1

- Closes https://github.com/honeycombio/helm-charts/issues/361

## Short description of the changes

- bump appVersion to 2.5.1
- bump chart version to 2.9.1
- update CI to check against refinery-2.X-work-branch instead of main

## How to verify that this has the expected result

Local testing