### PR TITLE
feat(refinery): Allow configuring probes

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 3.0.0-hnyinternal.2
+version: 3.0.0-hnyinternal.3
 appVersion: 3.0.0
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -113,13 +113,16 @@ spec:
             httpGet:
               path: /alive
               port: data
-            initialDelaySeconds: 10
-            periodSeconds: 3
+            {{- with .Values.livenessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /ready
               port: data
-            periodSeconds: 1
+            {{- with .Values.readinessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
       {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -105,6 +105,22 @@ resources:
     cpu: 2
     memory: 500Mi
 
+# liveness probe configuration
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 1
+
+# readiness probe configuration
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 1
+  timeoutSeconds: 1
+  failureThreshold: 1
+
 image:
   # temp repo value to get CI to pass
   repository: tylerhelmuthhc/refinery


### PR DESCRIPTION
## Which problem is this PR solving?

Allows users to configure readiness and liveness probes values

## Short description of the changes

- allows setting `initialDelaySeconds`, `periodSeconds`, `timeoutSeconds`, and `failureThreshold` for `livenessProbe` and `readinessProbe`.

## How to verify that this has the expected result

Tested locally
