### PR TITLE
rel: bump default refinery version to 2.5.2

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.9.1
-appVersion: 2.5.1
+version: 2.9.2
+appVersion: 2.5.2
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Bumps the default refinery version to 2.5.2

- Closes https://github.com/honeycombio/helm-charts/issues/366
- Closes https://github.com/honeycombio/helm-charts/issues/365

## Short description of the changes
- bump appVersion to 2.5.2

## How to verify that this has the expected result
Local tests