### PR TITLE
maint: remove refinery target branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,10 @@ jobs:
             minikube start --driver=none --kubernetes-version=${K8S_VERSION}
       - run:
           name: Lint charts
-          command: ct lint --config ./ct.yaml --target-branch refinery-2.X-work-branch
+          command: ct lint --config ./ct.yaml
       - run:
           name: Test charts
-          command: ct install --config ./ct.yaml --target-branch refinery-2.X-work-branch
+          command: ct install --config ./ct.yaml
 
 
   release-charts:


### PR DESCRIPTION
## Which problem is this PR solving?

Updates CI to use main again

## Short description of the changes

removes the `--target-branch` flag from CI

## How to verify that this has the expected result
