### PR TITLE
rel: Bump Refinery to v2.6.1

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.9.3
-appVersion: 2.5.2
+version: 2.10.0
+appVersion: 2.6.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 2.10.0
-appVersion: 2.6.0
+appVersion: 2.6.1
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Prepares the v2.10.0 release of the Refinery chart based on Refinery v2.6.1.

## Short description of the changes

- Update chart version to 2.10.0
- Update refinery version to 2.6.1
