### PR TITLE
feat(refinery): enable templating for liveness and readiness probe

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.10.0
-appVersion: 2.6.1
+version: 2.11.0
+appVersion: 2.7.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 2.11.0
-appVersion: 2.7.0
+appVersion: 2.7.0-dev
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.0
+version: 2.11.0-hnyinternal.0
 appVersion: 2.7.0-dev
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -112,16 +112,16 @@ spec:
             httpGet:
               path: /alive
               port: data
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            failureThreshold: 3
+          {{- with .Values.livenessProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           readinessProbe:
             httpGet:
-              path: /alive
+              path: /ready
               port: data
-            initialDelaySeconds: 0
-            periodSeconds: 3
-            failureThreshold: 5
+          {{- with .Values.readinessProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
       {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -104,6 +104,22 @@ resources:
     cpu: 500m
     memory: 500Mi
 
+# liveness probe configuration
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 1
+  failureThreshold: 3
+
+# readiness probe configuration
+# Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+readinessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 1
+  timeoutSeconds: 1
+  failureThreshold: 3
+
 image:
   repository: honeycombio/refinery
   pullPolicy: IfNotPresent

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -107,7 +107,7 @@ resources:
 # liveness probe configuration
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  initialDelaySeconds: 10
+  initialDelaySeconds: 5
   periodSeconds: 3
   timeoutSeconds: 1
   failureThreshold: 3
@@ -115,10 +115,10 @@ livenessProbe:
 # readiness probe configuration
 # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 readinessProbe:
-  initialDelaySeconds: 0
+  initialDelaySeconds: 5
   periodSeconds: 1
   timeoutSeconds: 1
-  failureThreshold: 3
+  failureThreshold: 1
 
 image:
   repository: honeycombio/refinery


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Refinery 2.7 has set up health check endpoints for readiness and liveness probes from k8s

## Short description of the changes

- templating liveness and readiness probe in Refinery Deployment spec

## How to verify that this has the expected result
local testing