### PR TITLE
feat(refinery): Set ShutdownDelay based on terminationGracePeriodSeconds

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -3,7 +3,7 @@ name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
 version: 2.11.2-hnyinternal.0
-appVersion: 2.8.0-dev
+appVersion: 2.8.0-dev.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.1
-appVersion: 2.7.1
+version: 2.11.2
+appVersion: 2.8.0
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.2
-appVersion: 2.8.0
+version: 2.11.2-hnyinternal.0
+appVersion: 2.8.0-dev
 keywords:
   - refinery
   - honeycomb

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
       {{- toYaml . | nindent 8 }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -24,6 +24,7 @@ config:
     Host: '{{include "refinery.redis.fullname" .}}:6379'
 
   Collection:
+    ShutdownDelay: '{{ sub .Values.terminationGracePeriodSeconds 5 }}s'
     # AvailableMemory is the amount of system memory available to the Refinery process.
     AvailableMemory: '{{ .Values.resources.limits.memory }}'
     MaxMemoryPercentage: 75
@@ -318,6 +319,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+terminationGracePeriodSeconds: 35
 
 # PodDisruptionBudget:
 #


### PR DESCRIPTION
## Which problem is this PR solving?

Refinery 2.8 attempts to drain data to remaining peers on shutdown, and has a configurable ShutdownDelay field where it tries to process remaining work while shutting down. In k8s we need this config option to be inline with terminationGracePeriodSeconds to ensure k8s doesn't kill pods early.

it's the same change as #360 
## Short description of the changes
- added terminationGracePeriodSeconds configuration option in values.yaml
- set ShutdownDelay to be terminationGracePeriodSeconds - 5 seconds by default. Users can override this value in their values.yaml
- publish a `-hnyinternal` tag for the change


## How to verify that this has the expected result
Test localling using kind