### PR TITLE
feat(refinery): bump Refinery to 2.8.2

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.2
-appVersion: 2.8.1
+version: 2.11.3
+appVersion: 2.8.2
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

- bump default refinery version to 2.8.2 in the chart