### PR TITLE
fix: add chart deps during release

### DIFF
--- a/.circleci/release.sh
+++ b/.circleci/release.sh
@@ -40,6 +40,8 @@ main() {
   readarray -t changed_charts <<<"$(lookup_changed_charts "$latest_tag")"
 
   if [[ -n "${changed_charts[*]}" ]]; then
+    add_dependencies
+
     rm -rf .cr-release-packages
     mkdir -p .cr-release-packages
 
@@ -93,6 +95,12 @@ lookup_changed_charts() {
   local fields="1-${depth}"
 
   cut -d '/' -f "$fields" <<<"$changed_files" | uniq | filter_charts
+}
+
+add_dependencies() {
+  echo "Adding chart dependencies"
+  helm repo add honeycomb https://honeycombio.github.io/helm-charts
+  helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
 }
 
 package_chart() {


### PR DESCRIPTION
## Which problem is this PR solving?

The last release failed bc `cr package` depends on any chart dependencies being present. 

## Short description of the changes

- runs `helm repo add` commands to add the required dependencies, similar to https://github.com/open-telemetry/opentelemetry-helm-charts/blob/43bf93cda3f16ba06c095d82c262f84886d90aae/.github/workflows/release.yaml#L27-L33
