### PR TITLE
feat(refinery): add support for topologySpreadConstraints

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.4
+version: 2.12.0
 appVersion: 2.8.2
 keywords:
   - refinery

--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.11.3
+version: 2.11.4
 appVersion: 2.8.2
 keywords:
   - refinery

--- a/charts/refinery/README.md
+++ b/charts/refinery/README.md
@@ -152,6 +152,7 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `redis.image.tag` | Redis image tag | `6.0.2` |
 | `redis.nodeSelector` | Node labels for pod assignment specific to the installed Redis deployment | `{}` |
 | `redis.tolerations` | Tolerations for pod assignment specific to the installed Redis deployment | `[]`|
+| `redis.topologySpreadConstraints` | TopologySpreadConstraints for pod assignment specific to the installed Redis deployment | `[]`|
 | `replicaCount` | Number of Refinery replicas | `3` |
 | `resources` | CPU/Memory resource requests/limits | limit: 2000m/2Gi, request: 500m/500Mi |
 | `rules` | Refinery sampling rules | see [Configuring sampling rules](#configuring-sampling-rules) |
@@ -169,6 +170,7 @@ The following table lists the configurable parameters of the Refinery chart, and
 | `serviceAccount.labels` | Labels to be applied to ServiceAccount | `{}` |
 | `serviceAccount.name` | The name of the ServiceAccount to create | Generated using the `refinery.fullname` template |
 | `tolerations` | Tolerations for pod assignment | `[]`|
+| `topologySpreadConstraints` | TopologySpreadConstraints for pod assignment | `[]`|
 
 1. secretProvider functionality requires the [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/)
 

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -70,6 +70,10 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.redis.tolerations }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/templates/deployment-redis.yaml
+++ b/charts/refinery/templates/deployment-redis.yaml
@@ -69,11 +69,11 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.redis.tolerations }}
+      {{- with .Values.redis.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- with .Values.redis.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -154,11 +154,11 @@ spec:
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- with .Values.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -155,6 +155,10 @@ spec:
       {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -208,6 +208,7 @@ redis:
 
   # Affinity specific to installed Redis configuration. Requires redis.enabled to be true
   affinity: {}
+  topologySpreadConstraints: []
   annotations: {}
   podAnnotations: {}
   podLabels: {}
@@ -317,6 +318,7 @@ rollout:
 nodeSelector: {}
 
 tolerations: []
+topologySpreadConstraints: []
 
 affinity: {}
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #97 

## Short description of the changes

Adds support for providing `topologySpreadConstraints` field. This will help us deploy refinery confirming to some topology constraints.