### PR TITLE
rel: k8s-agent chart v1.9.1 (deploys agent v2.7.3)

### DIFF
--- a/charts/honeycomb/Chart.yaml
+++ b/charts/honeycomb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: honeycomb
 description: Honeycomb Kubernetes Agent
-version: 1.9.0
-appVersion: 2.7.2
+version: 1.9.1
+appVersion: 2.7.3
 keywords:
   - observability
   - tracing


### PR DESCRIPTION
Honeycomb Kubernetes Agent chart:
* updated to deploy v2.7.3 of the agent
* chart version bumped to 1.9.1