### PR TITLE
maint: bump default refinery version to v2.8.4

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.12.1
-appVersion: 2.8.3
+version: 2.12.2
+appVersion: 2.8.4
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Update the chart to use refinery v2.8.4 by default.

## Short description of the changes

- bump appVersion
- bump chart version