### PR TITLE
feat(refinery): add deployment-marker support

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.13.0
+version: 2.14.0
 appVersion: 2.9.0
 keywords:
   - refinery

--- a/charts/refinery/templates/NOTES.txt
+++ b/charts/refinery/templates/NOTES.txt
@@ -4,3 +4,7 @@ within a few minutes at https://ui.honeycomb.io
 {{- if and .Values.podDisruptionBudget.minAvailable .Values.podDisruptionBudget.maxUnavailable }}
   {{- fail "podDisruptionBudget.minAvailable and podDisruptionBudget.maxUnavailable cannot be both specified at the same time." }}
 {{- end }}
+
+{{- if and .Values.deployMarker.enabled (or (not .Values.deployMarker.honeycombAPI) (not .Values.deployMarker.honeycombDataset)) }}
+{{- fail "To enable deployMarker, you must set both deployMarker.honeycombAPI and deployMarker.honeycombDataset." }}
+{{- end }}

--- a/charts/refinery/templates/deployment-marker-job.yaml
+++ b/charts/refinery/templates/deployment-marker-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.deployMarker.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -14,18 +15,27 @@ spec:
     spec:
       serviceAccountName: {{ include "refinery.serviceAccountName" . }}
       restartPolicy: Never
+      {{- with .Values.deployMarker.volumes }}
+      volumes:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-deploy-marker
           image: "{{ .Values.deployMarker.image.repository }}:{{ .Values.deployMarker.image.tag }}"
           imagePullPolicy: {{ .Values.deployMarker.image.pullPolicy }}
 
-          {{- with .Values.environment }}
+          {{- with .Values.deployMarker.environment }}
           env:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          {{- with .Values.deployMarker.volumeMounts }}
+          volumeMounts:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - -k
-            - "$(REFINERY_HONEYCOMB_API_KEY)"
+            - "$(REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY)"
             - -d
             - {{ .Values.deployMarker.honeycombDataset }}
             - --api_host
@@ -35,3 +45,4 @@ spec:
             - "Refinery {{ .Values.image.tag | default .Chart.AppVersion }}, Chart {{ .Chart.Version }}"
             - -t
             - deploy
+{{- end }}

--- a/charts/refinery/templates/deployment-marker-job.yaml
+++ b/charts/refinery/templates/deployment-marker-job.yaml
@@ -1,0 +1,37 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "refinery.fullname" . }}-deploy-marker
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "refinery.labels" . | nindent 4 }}
+
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: {{ include "refinery.serviceAccountName" . }}
+      restartPolicy: Never
+      containers:
+        - name: {{ .Chart.Name }}-deploy-marker
+          image: "{{ .Values.deployMarker.image.repository }}:{{ .Values.deployMarker.image.tag }}"
+          imagePullPolicy: {{ .Values.deployMarker.image.pullPolicy }}
+
+          {{- with .Values.environment }}
+          env:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args:
+            - -k
+            - "$(REFINERY_HONEYCOMB_API_KEY)"
+            - -d
+            - {{ .Values.deployMarker.honeycombDataset }}
+            - --api_host
+            - {{ .Values.deployMarker.honeycombAPI | quote }}
+            - add
+            - -m
+            - "Refinery {{ .Values.image.tag | default .Chart.AppVersion }}, Chart {{ .Chart.Version }}"
+            - -t
+            - deploy

--- a/charts/refinery/templates/deployment-marker-job.yaml
+++ b/charts/refinery/templates/deployment-marker-job.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "refinery.labels" . | nindent 4 }}
 
   annotations:
-    "helm.sh/hook": post-upgrade
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -395,7 +395,14 @@ deployMarker:
     tag: "latest"
   honeycombAPI: ""
   honeycombDataset: ""
+  # make sure to set REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY for sending markers to honeycomb
   environment: {}
+  # - name: REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: honeycombmarker
+  #       key: api-key
+
   volumes: []
   volumeMounts: []
 

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -396,6 +396,7 @@ deployMarker:
   honeycombAPI: ""
   honeycombDataset: ""
   # make sure to set REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY for sending markers to honeycomb
+  # For now we require an env var name `REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY` to contain the api key
   environment: {}
   # - name: REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY
   #   valueFrom:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -384,3 +384,15 @@ debug:
   # Only used if debug is enabled.
   # This value will be used to set config.DebugServiceAddr if it is not already set.
   port: 6060
+
+
+deployMarker:
+  enabled: false
+  image:
+    repository: honeycombio/honeymarker
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "latest"
+  honeycombAPI: ""
+  honeycombDataset: ""
+

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -402,7 +402,5 @@ deployMarker:
   #     secretKeyRef:
   #       name: honeycombmarker
   #       key: api-key
-
   volumes: []
   volumeMounts: []
-

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -385,7 +385,10 @@ debug:
   # This value will be used to set config.DebugServiceAddr if it is not already set.
   port: 6060
 
-
+# This feature is EXPERIMENTAL and subject to breaking changes
+#
+# When enabled, the chart will use a post-install job to create a honeycomb marker
+# in the specified dataset to mark the install of the chart.
 deployMarker:
   enabled: false
   image:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -391,8 +391,11 @@ deployMarker:
   image:
     repository: honeycombio/honeymarker
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    # Overrides the image tag whose default is latest
     tag: "latest"
   honeycombAPI: ""
   honeycombDataset: ""
+  environment: {}
+  volumes: []
+  volumeMounts: []
 


### PR DESCRIPTION
## Which problem is this PR solving?

It's helpful to know when a new version of Refinery has been deployed when viewing Refinery's telemetry data. This PR adds a deployment marker job in Refinery's chart. The job will create a honeycomb marker when a Refinery deployment happenes.

NOTE: This is a MVP version of this feature. There could be other improvements made down the line

## Short description of the changes

- add a deployment-marker job. The job utilize helm hooks to only run after a `helm install` or `helm upgrade`
- introduce a new `REFINERY_HONEYCOMB_DEPLOY_MARKER_API_KEY` environment variable for sending deploy markers to honeycomb

## How to verify that this has the expected result
Tested it locally