### PR TITLE
feat(observability-pipeline): allow setting existing serviceAccount name

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.2-alpha
+version: 0.0.3-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpters.tpl
+++ b/charts/observability-pipeline/templates/_helpters.tpl
@@ -58,3 +58,14 @@ Selector labels
 app.kubernetes.io/name: {{ include "honeycomb-observability-pipeline.name" . }}-control-plane
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the name of the service account to use for the control plane
+*/}}
+{{- define "honeycomb-observability-pipeline.serviceAccountName" -}}
+{{- if .Values.controlPlane.serviceAccount.create }}
+{{- default (printf "%s-control-plane" (include "honeycomb-observability-pipeline.fullname" .)) .Values.controlPlane.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.controlPlane.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -19,7 +19,7 @@ spec:
         {{- include "honeycomb-observability-pipeline.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: control-plane
     spec:
-      serviceAccountName: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
+      serviceAccountName: {{ include "honeycomb-observability-pipeline.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"

--- a/charts/observability-pipeline/templates/control-plane-serviceaccount.yaml
+++ b/charts/observability-pipeline/templates/control-plane-serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.refinery.enabled }}
+{{- if .Values.controlPlane.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
+  name: {{ include "honeycomb-observability-pipeline.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -14,6 +14,9 @@ refinery:
     - 'http://{{ include "honeycomb-observability-pipeline.name" . }}-observability-pipeline-control-plane:4321/config?kind=refinery_rules'
 
 controlPlane:
+  serviceAccount:
+    create: true
+    name: ""
   image:
     repository: ""
     pullPolicy: IfNotPresent


### PR DESCRIPTION
## Which problem is this PR solving?

Allows users to disable creating a service account for the control plane and instead specify the name of an existing service account to use.

## Short description of the changes

- add serviceAccount subsection to controlPlane
- add logic to use the serviceAccount.name if it is set 

## How to verify that this has the expected result

Tested locally
