### PR TITLE
feat(observability-pipeline): add control plane telemetry support

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.3-alpha
+version: 0.0.4-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpters.tpl
+++ b/charts/observability-pipeline/templates/_helpters.tpl
@@ -69,3 +69,11 @@ Create the name of the service account to use for the control plane
 {{- default "default" .Values.controlPlane.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Build otel config file for Control Plane
+*/}}
+{{- define "honeycomb-observability-pipeline.controlPlaneOTelConfig" -}}
+{{- tpl (toYaml .Values.controlPlane.telemetry.config) . }}
+{{- end }}
+

--- a/charts/observability-pipeline/templates/control-plane-configmap-otel.yaml
+++ b/charts/observability-pipeline/templates/control-plane-configmap-otel.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.refinery.enabled .Values.controlPlane.telemetry.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
+data:
+  otel-config: |
+  {{- include "honeycomb-observability-pipeline.controlPlaneOTelConfig" . | nindent 4 -}}
+{{- end }}

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    app.kubernetes.io/component: control-plane
 spec:
   replicas: 1
   selector:
@@ -24,6 +25,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          {{- if .Values.controlPlane.telemetry.enabled }}
+          args:
+            - -otel-config
+            - /etc/straws-control-plane/otel-config.yaml
+          {{- end }}
           env:
             - name: HONEYCOMB_API
               value: {{ .Values.controlPlane.endpoint }}
@@ -36,16 +42,32 @@ spec:
             {{- with .Values.controlPlane.environment }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with .Values.controlPlane.volumeMounts }}
+          {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled }}
           volumeMounts:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}        
+          {{- if .Values.controlPlane.telemetry.enabled }}
+            - name: otel-config
+              mountPath: /etc/straws-control-plane
+          {{- end }}  
+          {{- with .Values.controlPlane.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}            
           ports:
             - name: config
               containerPort: 4321
               protocol: TCP
-      {{- with .Values.controlPlane.volumes }}
+      {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled }}
       volumes:
-      {{- toYaml . | nindent 8 }}
+      {{- if .Values.controlPlane.telemetry.enabled }}
+        - name: otel-config
+          configMap:
+            name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
+            items:
+              - key: otel-config
+                path: otel-config.yaml
+      {{- end }}  
+      {{- with .Values.controlPlane.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -31,8 +31,33 @@ controlPlane:
         secretKeyRef:
           name: honeycomb-observability-pipeline
           key: management-api-secret
+    - name: HONEYCOMB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-observability-pipeline
+          key: api-key
   volumes: []
   volumeMounts: []
+  telemetry:
+    enabled: false
+    config:
+      file_format: "0.3"
+      resource:
+        schema_url: https://opentelemetry.io/schemas/1.26.0
+        attributes:
+          - name: service.name
+            value: "straws-control-plane"
+          - name: service.version
+            value: "0.0.1"
+      propagator:
+        composite: [ tracecontext, baggage ]
+      tracer_provider:
+        processors:
+          - batch:
+              exporter:
+                otlp:
+                  protocol: http/protobuf
+                  endpoint: http://{{ include "honeycomb-observability-pipeline.name" . }}-otelcol-deployment:4318
 
 otelcol-deployment:
   enabled: false
@@ -43,7 +68,7 @@ otelcol-deployment:
     - name: HONEYCOMB_API_KEY
       valueFrom:
         secretKeyRef:
-          name: honeycomb
+          name: honeycomb-observability-pipeline
           key: api-key
   # We only want one of these collectors - any more and we'd produce duplicate data
   replicaCount: 1

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -50,7 +50,9 @@ controlPlane:
           - name: service.version
             value: "0.0.1"
       propagator:
-        composite: [ tracecontext, baggage ]
+        composite:
+          - tracecontext
+          - baggage
       tracer_provider:
         processors:
           - batch:


### PR DESCRIPTION
## Which problem is this PR solving?

Adds ability to enable the control plane's instrumentation using otel's sdk configuration. When enabled, the chart will include and mount a configmap for configuring the exporting of the control plane's telemetry.

## Short description of the changes

- add new configmap template
- add conditions to the control plane deployment to hook up config
- add default otel sdk config to push to the gateway collector that can be installed by this chart. This is the default instead of pushing to honeycomb because the otel configuraiton doesn't support env vars yet, so there isn't a way to pass in our honeycomb ingest key as a secret. Instead the default is to export the data to a collector which can properly manage the secret (and enhance with k8s attributes). 

## How to verify that this has the expected result

Tested locally.
