### PR TITLE
fix(refinery): deployment marker image pull secrets and job name uniqueness

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.15.1
+version: 2.15.2
 appVersion: 2.9.1
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment-marker-job.yaml
+++ b/charts/refinery/templates/deployment-marker-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "refinery.fullname" . }}-deploy-marker
+  name: {{ include "refinery.fullname" . }}-deploy-marker-{{ randAlphaNum 5 | lower }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
@@ -15,6 +15,10 @@ spec:
     spec:
       serviceAccountName: {{ include "refinery.serviceAccountName" . }}
       restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.deployMarker.volumes }}
       volumes:
       {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Which problem is this PR solving?

- Allow refinery pods to authenticate and pull honeymarker image.
- Add uniqueness for deployment marker job name so that concurrent deployment won't fail

## Short description of the changes
- use the same `imagePullSecrets` from refinery for deployment marker
- add a randomly generated string to deployment marker job name

## How to verify that this has the expected result
tested locally