### PR TITLE
feat(observability-pipeline): Add default refinery telemetry api key

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.5-alpha
+version: 0.0.6-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -7,6 +7,12 @@ refinery:
       Enabled: false
     OTelMetrics:
       Enabled: true
+  environment:
+    - name: REFINERY_HONEYCOMB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-observability-pipeline
+          key: api-key
   extraCommandArgs:
     - "-c"
     - 'http://{{ include "honeycomb-observability-pipeline.name" . }}-observability-pipeline-control-plane:4321/config?kind=refinery_config'


### PR DESCRIPTION
## Which problem is this PR solving?

Sets a default `REFINERY_HONEYCOMB_API_KEY` env var so that refinery can export telemetry using a default install.

## Short description of the changes

- Add a default env var named REFINERY_HONEYCOMB_API_KEY that looks for the secret that users are instructed to create in the README

## How to verify that this has the expected result

Local testing.
