### PR TITLE
feat(observability-pipeline): rename configuration_id to installation_id

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.7-alpha
+version: 0.0.8-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -35,7 +35,7 @@ spec:
               value: {{ .Values.controlPlane.endpoint }}
             - name: HONEYCOMB_TEAM
               value: {{ .Values.controlPlane.team }}
-            - name: HONEYCOMB_CONFIGURATION_ID
+            - name: HONEYCOMB_INSTALLATION_ID
               value: {{ .Values.controlPlane.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY
               value: {{ .Values.controlPlane.publicMgmtKey }}


### PR DESCRIPTION
## Which problem is this PR solving?

I renamed the env var in control-place from configuration id to installation id https://github.com/honeycombio/straws-control-plane/pull/24

This PR is to match the helm-chart with the control place change

## Short description of the changes
rename configuration id to installation id

