### PR TITLE
feat(observability-pipeline): add opampsupervisor support

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.8-alpha
+version: 0.0.9-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/ci/collectors-values.yaml
+++ b/charts/observability-pipeline/ci/collectors-values.yaml
@@ -1,6 +1,9 @@
 refinery:
   enabled: false
 
+collector:
+  enabled: false
+
 otelcol-deployment:
   enabled: true
   extraEnvs: []

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -35,11 +35,11 @@ Honeycomb Observability Pipeline is setup and configured.
 {{- if .Values.collector.enabled }}
 
   {{- if (not .Values.collector.image.repository) }}
-    {{- fail "controlPlane.image.repository must be set" }}
+    {{- fail "collector.image.repository must be set" }}
   {{- end }}
 
   {{- if (not .Values.collector.image.tag) }}
-    {{- fail "controlPlane.image.tag must be set" }}
+    {{- fail "collector.image.tag must be set" }}
   {{- end }}
 
 {{- end }}

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -31,3 +31,15 @@ Honeycomb Observability Pipeline is setup and configured.
   {{- end }}
 
 {{- end }}
+
+{{- if .Values.collector.enabled }}
+
+  {{- if (not .Values.collector.image.repository) }}
+    {{- fail "controlPlane.image.repository must be set" }}
+  {{- end }}
+
+  {{- if (not .Values.collector.image.tag) }}
+    {{- fail "controlPlane.image.tag must be set" }}
+  {{- end }}
+
+{{- end }}

--- a/charts/observability-pipeline/templates/collector-configmap.yaml
+++ b/charts/observability-pipeline/templates/collector-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.collector.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+data:
+  config: |
+  {{- include "honeycomb-observability-pipeline.collectorConfig" . | nindent 4 -}}
+{{- end }}

--- a/charts/observability-pipeline/templates/collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/collector-deployment.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.collector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+spec:
+  replicas: {{ .Values.collector.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "honeycomb-observability-pipeline.collector.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "honeycomb-observability-pipeline.collector.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: collector
+    spec:
+      serviceAccountName: {{ include "honeycomb-observability-pipeline.collector.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.collector.image.repository }}:{{ .Values.collector.image.tag }}"
+          imagePullPolicy: {{ .Values.collector.image.pullPolicy }}
+          args:
+            - --config
+            - /etc/opampsupervisor/config.yaml
+          {{- with .Values.collector.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/opampsupervisor
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "honeycomb-observability-pipeline.fullname" . }}-collector
+            items:
+              - key: config
+                path: config.yaml
+{{- end }}

--- a/charts/observability-pipeline/templates/collector-service.yaml
+++ b/charts/observability-pipeline/templates/collector-service.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.collector.enabled .Values.collector.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+spec:
+  type: ClusterIP
+  ports:
+    {{- toYaml .Values.collector.service.ports | nindent 4 }}
+  selector:
+    {{- include "honeycomb-observability-pipeline.collector.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/observability-pipeline/templates/collector-serviceaccount.yaml
+++ b/charts/observability-pipeline/templates/collector-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.collector.enabled .Values.collector.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.collector.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.collector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+{{- end }}

--- a/charts/observability-pipeline/templates/control-plane-configmap-otel.yaml
+++ b/charts/observability-pipeline/templates/control-plane-configmap-otel.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.controlPlane.labels" . | nindent 4 }}
     app.kubernetes.io/component: control-plane
 data:
   otel-config: |

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -5,22 +5,22 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.controlPlane.labels" . | nindent 4 }}
     app.kubernetes.io/component: control-plane
 spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "honeycomb-observability-pipeline.selectorLabels" . | nindent 6 }}
+      {{- include "honeycomb-observability-pipeline.controlPlane.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        {{- include "honeycomb-observability-pipeline.selectorLabels" . | nindent 8 }}
+        {{- include "honeycomb-observability-pipeline.controlPlane.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: control-plane
     spec:
-      serviceAccountName: {{ include "honeycomb-observability-pipeline.serviceAccountName" . }}
+      serviceAccountName: {{ include "honeycomb-observability-pipeline.controlPlane.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
@@ -59,6 +59,9 @@ spec:
           ports:
             - name: config
               containerPort: 4321
+              protocol: TCP
+            - name: opamp
+              containerPort: 4320
               protocol: TCP
       {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled }}
       volumes:

--- a/charts/observability-pipeline/templates/control-plane-service.yaml
+++ b/charts/observability-pipeline/templates/control-plane-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-control-plane
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.controlPlane.labels" . | nindent 4 }}
     app.kubernetes.io/component: control-plane
 spec:
   type: ClusterIP
@@ -14,6 +14,10 @@ spec:
       targetPort: "config"
       protocol: TCP
       name: config
+    - port: 4320
+      targetPort: "opamp"
+      protocol: TCP
+      name: opamp
   selector:
-    {{- include "honeycomb-observability-pipeline.selectorLabels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.controlPlane.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/observability-pipeline/templates/control-plane-serviceaccount.yaml
+++ b/charts/observability-pipeline/templates/control-plane-serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "honeycomb-observability-pipeline.serviceAccountName" . }}
+  name: {{ include "honeycomb-observability-pipeline.controlPlane.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipeline.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.controlPlane.labels" . | nindent 4 }}
     app.kubernetes.io/component: control-plane
 {{- end }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -75,6 +75,31 @@ controlPlane:
                   protocol: http/protobuf
                   endpoint: http://{{ include "honeycomb-observability-pipeline.name" . }}-otelcol-deployment:4318
 
+collector:
+  enabled: true
+  serviceAccount:
+    create: true
+    name: ""
+  service:
+    enabled: true
+    ports:
+      - name: otlp
+        port: 4317
+        targetPort: 4317
+        protocol: TCP
+        appProtocol: grpc
+      - name: otlp-http
+        port: 4318
+        targetPort: 4318
+        protocol: TCP
+  resources: {}
+  replicaCount: 2
+  image:
+    repository: ""
+    pullPolicy: IfNotPresent
+    tag: ""
+
+
 otelcol-deployment:
   enabled: false
   mode: deployment


### PR DESCRIPTION
## Which problem is this PR solving?

Allows the chart to install an opamp-managed collector (implemented via the opampsupervisor) that communicates with the control plane

## Short description of the changes

- update test to not install an opamp-managed collector
- update control-plane helper templates to be namespaced with `controlPlane`
- add template files for installing an opampsupervisor deployment.
- update NOTES.txt to enforce specifying an image for the opampsupervisor

## How to verify that this has the expected result

Tested locally in kind.
