### PR TITLE
maint(refinery): bump version to 2.15.3

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.15.2
-appVersion: 2.9.1
+version: 2.15.3
+appVersion: 2.9.2
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

We just released refinery 2.9.2. Update the chart to use the latest refinery version

