### PR TITLE
feat(observability-pipeline): add support for environments and volumes

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.9-alpha
+version: 0.0.10-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/collector-deployment.yaml
@@ -28,6 +28,10 @@ spec:
           args:
             - --config
             - /etc/opampsupervisor/config.yaml
+          {{- with .Values.collector.environment }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.collector.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -35,6 +39,9 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor
+          {{- with .Values.controlPlane.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: config
           configMap:
@@ -42,4 +49,7 @@ spec:
             items:
               - key: config
                 path: config.yaml
+      {{- with .Values.collector.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -55,7 +55,7 @@ spec:
           {{- with .Values.controlPlane.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- end }}            
+          {{- end }}
           ports:
             - name: config
               containerPort: 4321

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -98,6 +98,14 @@ collector:
     repository: ""
     pullPolicy: IfNotPresent
     tag: ""
+  environment:
+    - name: HONEYCOMB_API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-observability-pipeline
+          key: api-key
+  volumes: []
+  volumeMounts: []
 
 
 otelcol-deployment:


### PR DESCRIPTION
## Which problem is this PR solving?

Add ability to set environment variables and volumes on the collector pods.

## Short description of the changes

- add env support
- add volume support
- add volumeMount support
- add default env var

## How to verify that this has the expected result

tested in sippycup