### PR TITLE
feat(observability-pipeline): use pvc for cacheing latest config

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.10-alpha
+version: 0.0.11-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -25,10 +25,14 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
-          {{- if .Values.controlPlane.telemetry.enabled }}
           args:
+          {{- if .Values.controlPlane.telemetry.enabled }}
             - -otel-config
             - /etc/straws-control-plane/otel-config.yaml
+          {{- end }}
+          {{- if .Values.controlPlane.persistentVolumeClaimName }}
+            - -config-cache-path
+            - /app/straws-control-plane/cache
           {{- end }}
           env:
             - name: HONEYCOMB_API
@@ -52,6 +56,11 @@ spec:
             - name: otel-config
               mountPath: /etc/straws-control-plane
           {{- end }}  
+          {{- if .Values.controlPlane.persistentVolumeClaimName }}
+            - name: latest-config-cache
+              mountPath: /app/straws-control-plane/cache
+              readonly: false
+          {{- end }}
           {{- with .Values.controlPlane.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -73,6 +82,10 @@ spec:
               - key: otel-config
                 path: otel-config.yaml
       {{- end }}  
+      {{- if .Values.controlPlane.persistentVolumeClaimName }}
+        - name: latest-config-cache
+          persistentVolumeClaimName: {{ .Values.controlPlane.persistentVolumeClaimName }}
+      {{- end }}
       {{- with .Values.controlPlane.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled }}
+          {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled .Values.controlPlane.persistentVolumeClaimName }}
           volumeMounts:
           {{- if .Values.controlPlane.telemetry.enabled }}
             - name: otel-config
@@ -72,7 +72,7 @@ spec:
             - name: opamp
               containerPort: 4320
               protocol: TCP
-      {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled }}
+      {{- if or .Values.controlPlane.volumeMounts .Values.controlPlane.telemetry.enabled .Values.controlPlane.persistentVolumeClaimName }}
       volumes:
       {{- if .Values.controlPlane.telemetry.enabled }}
         - name: otel-config

--- a/charts/observability-pipeline/templates/control-plane-deployment.yaml
+++ b/charts/observability-pipeline/templates/control-plane-deployment.yaml
@@ -25,6 +25,7 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.controlPlane.image.repository }}:{{ .Values.controlPlane.image.tag }}"
           imagePullPolicy: {{ .Values.controlPlane.image.pullPolicy }}
+          {{- if or .Values.controlPlane.telemetry.enabled .Values.controlPlane.persistentVolumeClaimName }}
           args:
           {{- if .Values.controlPlane.telemetry.enabled }}
             - -otel-config
@@ -33,6 +34,7 @@ spec:
           {{- if .Values.controlPlane.persistentVolumeClaimName }}
             - -config-cache-path
             - /app/straws-control-plane/cache
+          {{- end }}
           {{- end }}
           env:
             - name: HONEYCOMB_API

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -32,6 +32,7 @@ controlPlane:
   pipelineInstallationID: ""
   team: ""
   publicMgmtKey: ""
+  persistentVolumeClaimName: ""
   environment:
     - name: HONEYCOMB_MGMT_API_SECRET
       valueFrom:


### PR DESCRIPTION
## Which problem is this PR solving?

- adds support for using pvc to persist latest config in control plane

## Short description of the changes

- add a new `persistentVolumnClaimName` in the `values.yaml` file to allow users to mount a volume
- pass in the mount path using `-config-cache-path` flag

## How to verify that this has the expected result
