### PR TITLE
fix: Normalize `ingressClassName` nesting in Refinery chart in accordance with README

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.15.3
+version: 2.15.4
 appVersion: 2.9.2
 keywords:
   - refinery

--- a/charts/refinery/templates/ingress.yaml
+++ b/charts/refinery/templates/ingress.yaml
@@ -25,8 +25,8 @@ spec:
       secretName: {{ .secretName }}
     {{- end }}
   {{- end }}
-  {{- if .Values.ingressClassName }}
-  ingressClassName: {{ .Values.ingressClassName }}
+  {{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}


### PR DESCRIPTION
Fixes #422

Nest `ingressClassName` under `ingress` in the Refinery chart.

* Move `ingressClassName` under the `ingress` key in `charts/refinery/templates/ingress.yaml`
* Update the indentation to match the new structure
* Modify the condition to check for `ingress.ingressClassName` instead of `ingressClassName`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/honeycombio/helm-charts/pull/423?shareId=9b5a973b-2be3-4014-80d4-700172ce5f62).