### PR TITLE
fix(htp): fix bug where username/password could not come from secret

### DIFF
--- a/charts/htp/Chart.yaml
+++ b/charts/htp/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp
 description: Honeycomb Telemetry Pipeline
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.85.0
 home: https://honeycomb.io
 sources:

--- a/charts/htp/README.md
+++ b/charts/htp/README.md
@@ -27,7 +27,7 @@ kubectl create secret generic hny-secrets \
   --from-literal=license=$LICENSE_KEY \
   --from-literal=sessions_secret=$(uuidgen) \
   --from-literal=username=admin \
-  --from-literal=password=admin \
+  --from-literal=password=admin
 
 helm install htp honeycomb/htp
 ```
@@ -44,7 +44,7 @@ helm install htp honeycomb/htp \
   --set htp.config.license=$LICENSE_KEY \
   --set htp.config.sessions_secret=$(uuidgen) \
   --set htp.config.username='admin' \
-  --set htp.config.password='admin' \
+  --set htp.config.password='admin'
 ```
 
 ### Port-forward to view in UI

--- a/charts/htp/README.md
+++ b/charts/htp/README.md
@@ -25,7 +25,9 @@ export LICENSE_KEY='your-license-key'
 
 kubectl create secret generic hny-secrets \
   --from-literal=license=$LICENSE_KEY \
-  --from-literal=sessions_secret=$(uuidgen)
+  --from-literal=sessions_secret=$(uuidgen) \
+  --from-literal=username=admin \
+  --from-literal=password=admin \
 
 helm install htp honeycomb/htp
 ```
@@ -40,7 +42,9 @@ export LICENSE_KEY='your-license-key'
 helm install htp honeycomb/htp \
   --set htp.config.licenseUseSecret=false \
   --set htp.config.license=$LICENSE_KEY \
-  --set htp.config.sessions_secret=$(uuidgen)
+  --set htp.config.sessions_secret=$(uuidgen) \
+  --set htp.config.username='admin' \
+  --set htp.config.password='admin' \
 ```
 
 ### Port-forward to view in UI

--- a/charts/htp/values.yaml
+++ b/charts/htp/values.yaml
@@ -3,9 +3,9 @@
 htp:
   config:
     # Basic auth username to use for the default admin user
-    username: 'admin'
+    username: ''
     # Basic auth password to use for the default admin user
-    password: 'admin'
+    password: ''
     # Random UUIDv4 used to derive web interface session tokens
     sessions_secret: ''
     # Honeycomb HTP License Key


### PR DESCRIPTION
## Which problem is this PR solving?

- fixes an issue where the default username and password in the values.yaml were taking priority over any username/password set in the `config.secret`. This is an outcome of the bindplane chart: https://github.com/observIQ/bindplane-op-helm/blob/main/charts/bindplane/templates/bindplane.yaml#L135-L154

## Short description of the changes

- remove default username and password values.
- update readme instructions

## How to verify that this has the expected result

tested locally
