### PR TITLE
feat(observability-pipeline): Add config checksum to annotations

### DIFF
--- a/charts/observability-pipeline/Chart.lock
+++ b/charts/observability-pipeline/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: refinery
   repository: https://honeycombio.github.io/helm-charts
-  version: 2.15.1
+  version: 2.15.3
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.111.0
+  version: 0.117.1
 - name: opentelemetry-collector
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
-  version: 0.111.0
-digest: sha256:44614ed0ae98151ec9e18784b8919d6316e9695e9fc12c2ecb40e3dad90b20a1
-generated: "2024-12-18T08:36:36.990175-07:00"
+  version: 0.117.1
+digest: sha256:a68bc15c58173991db8f1de062c83627b7a3842ebdee3b34b0a692c310b7ed8e
+generated: "2025-03-03T16:24:35.732927-07:00"

--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.14-alpha
+version: 0.0.15-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery
@@ -22,16 +22,16 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
 - name: refinery
-  version: 2.15.1
+  version: 2.15.3
   repository: "https://honeycombio.github.io/helm-charts"
   condition: refinery.enabled
 - name: opentelemetry-collector
-  version: 0.111.0
+  version: 0.117.1
   repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
   alias: otelcol-deployment
   condition: otelcol-deployment.enabled
 - name: opentelemetry-collector
-  version: 0.111.0
+  version: 0.117.1
   repository: "https://open-telemetry.github.io/opentelemetry-helm-charts"
   alias: otelcol-daemonset
   condition: otelcol-daemonset.enabled

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -78,6 +78,13 @@ Build otel config file for beekeeper
 {{- end }}
 
 {{/*
+Create ConfigMap checksum annotation if configMap.existingPath is defined, otherwise use default templates
+*/}}
+{{- define "honeycomb-observability-pipeline.beekeeper.configTemplateChecksumAnnotation" -}}
+  checksum/config: {{ include (print $.Template.BasePath "/beekeeper-configmap-otel.yaml") . | sha256sum }}
+{{- end }}
+
+{{/*
 Build config file for collector
 */}}
 {{- define "honeycomb-observability-pipeline.collectorConfig" -}}
@@ -136,4 +143,11 @@ Collector Selector labels
 {{- define "honeycomb-observability-pipeline.collector.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "honeycomb-observability-pipeline.name" . }}-collector
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create ConfigMap checksum annotation if configMap.existingPath is defined, otherwise use default templates
+*/}}
+{{- define "honeycomb-observability-pipeline.collector.configTemplateChecksumAnnotation" -}}
+  checksum/config: {{ include (print $.Template.BasePath "/collector-configmap.yaml") . | sha256sum }}
 {{- end }}

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -78,7 +78,7 @@ Build otel config file for beekeeper
 {{- end }}
 
 {{/*
-Create ConfigMap checksum annotation if configMap.existingPath is defined, otherwise use default templates
+Create ConfigMap checksum annotation for beekeeper
 */}}
 {{- define "honeycomb-observability-pipeline.beekeeper.configTemplateChecksumAnnotation" -}}
   checksum/config: {{ include (print $.Template.BasePath "/beekeeper-configmap-otel.yaml") . | sha256sum }}
@@ -146,7 +146,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
-Create ConfigMap checksum annotation if configMap.existingPath is defined, otherwise use default templates
+Create ConfigMap checksum annotation for collector
 */}}
 {{- define "honeycomb-observability-pipeline.collector.configTemplateChecksumAnnotation" -}}
   checksum/config: {{ include (print $.Template.BasePath "/collector-configmap.yaml") . | sha256sum }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        {{- include "honeycomb-observability-pipeline.beekeeper.configTemplateChecksumAnnotation" . | nindent 8 }}
       labels:
         {{- include "honeycomb-observability-pipeline.beekeeper.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: beekeeper

--- a/charts/observability-pipeline/templates/collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/collector-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        {{- include "honeycomb-observability-pipeline.collector.configTemplateChecksumAnnotation" . | nindent 8 }}
       labels:
         {{- include "honeycomb-observability-pipeline.collector.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: collector


### PR DESCRIPTION
## Which problem is this PR solving?

Ensure that if config changes for beekeeper or the opampsupervisor that the deployments are rolled.

## Short description of the changes

- Add template helpers to calculate checksum
- Add annotation to opampsupervisor and beekeeper deployments
- bump dep versions
- bump chart verison

## How to verify that this has the expected result

local helm template
