### PR TITLE
feat(observability-pipeline): use opamp by default

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.17-alpha
+version: 0.0.18-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -2,7 +2,13 @@ name: honeycomb-observability-pipeline
 
 refinery:
   enabled: true
+  image:
+    repository: "honeycombio/refinery"
+    tag: "2.9.3-htp-dev"
   config:
+    Network:
+      OpAMPEnabled: true
+      OpAMPEndpoint: "ws://{{ include \"honeycomb-observability-pipeline.name\" . }}-observability-pipeline-beekeeper:4320/v1/opamp"
     PrometheusMetrics:
       Enabled: false
     OTelMetrics:
@@ -13,11 +19,6 @@ refinery:
         secretKeyRef:
           name: honeycomb-observability-pipeline
           key: api-key
-  extraCommandArgs:
-    - "-c"
-    - 'http://{{ include "honeycomb-observability-pipeline.name" . }}-observability-pipeline-beekeeper:4321/config?kind=refinery_config'
-    - "-r"
-    - 'http://{{ include "honeycomb-observability-pipeline.name" . }}-observability-pipeline-beekeeper:4321/config?kind=refinery_rules'
 
 beekeeper:
   resources: {}


### PR DESCRIPTION
## Which problem is this PR solving?

Update the chart to use refinery opamp by default

## Short description of the changes

- set default refinery image
- enable opamp

## How to verify that this has the expected result

tested locally
