### PR TITLE
feat(observability-pipeline): Update default env vars to be a map

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.19-alpha
+version: 0.0.20-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -28,10 +28,6 @@
     {{- fail "beekeeper.publicMgmtKey must be set" }}
   {{- end }}
 
-  {{- if (not .Values.beekeeper.environment) }}
-    {{- fail "beekeeper.environment must be set to supply the HONEYCOMB_AUTH_HEADER environment variable" }}
-  {{- end }}
-
 {{- end }}
 
 {{- if .Values.collector.enabled }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -65,7 +65,23 @@ spec:
               value: {{ .Values.beekeeper.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY
               value: {{ .Values.beekeeper.publicMgmtKey }}
-            {{- with .Values.beekeeper.environment }}
+            {{- if .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.enabled }}
+            - name: HONEYCOMB_MGMT_API_SECRET
+              {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content | nindent 14 }}  
+            {{- end }}
+            {{- if .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.enabled }}
+            - name: HONEYCOMB_API_KEY
+              {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
+            {{- end }}
+            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_ENDPOINT.enabled }}
+            - name: TELEMETRY_ENDPOINT
+              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_ENDPOINT.content | nindent 14 }}  
+            {{- end }}
+            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_KEY.enabled }}
+            - name: TELEMETRY_KEY
+              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_KEY.content | nindent 14 }}  
+            {{- end }}
+            {{- with .Values.beekeeper.extraEnvs }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.beekeeper.resources }}

--- a/charts/observability-pipeline/templates/collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/collector-deployment.yaml
@@ -53,7 +53,11 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipelineInstallationID={{ .Values.beekeeper.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-            {{- with .Values.collector.environment }}
+            {{- if .Values.collector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
+            - name: HONEYCOMB_API_KEY
+              {{- toYaml .Values.collector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
+            {{- end }}
+            {{- with .Values.collector.extraEnvs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- with .Values.collector.resources }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -34,21 +34,30 @@ beekeeper:
   team: ""
   publicMgmtKey: ""
   persistentVolumeClaimName: ""
-  environment:
-    - name: HONEYCOMB_MGMT_API_SECRET
-      valueFrom:
-        secretKeyRef:
-          name: honeycomb-observability-pipeline
-          key: management-api-secret
-    - name: HONEYCOMB_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: honeycomb-observability-pipeline
-          key: api-key
-    - name: TELEMETRY_ENDPOINT
-      value: https://api.honeycomb.io:443
-    - name: TELEMETRY_KEY
-      value: "${env:HONEYCOMB_API_KEY}"
+  defaultEnv:
+    HONEYCOMB_MGMT_API_SECRET:
+      enabled: true
+      content:
+        valueFrom:
+          secretKeyRef:
+            name: honeycomb-observability-pipeline
+            key: management-api-secret
+    HONEYCOMB_API_KEY:
+      enabled: true
+      content:
+        valueFrom:
+          secretKeyRef:
+            name: honeycomb-observability-pipeline
+            key: api-key
+    TELEMETRY_ENDPOINT:
+      enabled: true
+      content:
+        value: https://api.honeycomb.io:443
+    TELEMETRY_KEY:
+      enabled: true
+      content:
+        value: "${env:HONEYCOMB_API_KEY}"
+  extraEnvs: []
   volumes: []
   volumeMounts: []
   telemetry:
@@ -104,12 +113,15 @@ collector:
     repository: ""
     pullPolicy: IfNotPresent
     tag: ""
-  environment:
-    - name: HONEYCOMB_API_KEY
-      valueFrom:
-        secretKeyRef:
-          name: honeycomb-observability-pipeline
-          key: api-key
+  defaultEnv:
+    HONEYCOMB_API_KEY:
+      enabled: true
+      content:
+        valueFrom:
+          secretKeyRef:
+            name: honeycomb-observability-pipeline
+            key: api-key
+  extraEnvs: []
   volumes: []
   volumeMounts: []
 


### PR DESCRIPTION
## Which problem is this PR solving?

Lists of env vars are hard to change because they can't be merged. Updated collector and beekeeper's default env vars to be a map so individual entries can easily be disabled or changed

- https://app.asana.com/0/1208469935858869/1209598578859275

## Short description of the changes

- reorganize values.yaml
- update beekeeper and collector env var list in deployments
- removed un-needed check in NOTE.txt
- add new extraEnvs option for beekeeper and collector to allow addition env vars

## How to verify that this has the expected result

Local templating
