### PR TITLE
maint(observability-pipeline): bump refinery version

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.20-alpha
+version: 0.0.21-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -4,11 +4,12 @@ refinery:
   enabled: true
   image:
     repository: "honeycombio/refinery"
-    tag: "2.9.3-htp-dev"
+    tag: "2.9.3-htp-dev.1"
   config:
     Network:
       OpAMPEnabled: true
       OpAMPEndpoint: "ws://{{ include \"honeycomb-observability-pipeline.name\" . }}-observability-pipeline-beekeeper:4320/v1/opamp"
+      OpAMPRecordUsage: false
     PrometheusMetrics:
       Enabled: false
     OTelMetrics:


### PR DESCRIPTION
## Which problem is this PR solving?

bump refinery version to `2.9.3-htp-dev.1`

## Short description of the changes

- bump default refinery version
- change default value for record usage for refinery

## How to verify that this has the expected result
