### PR TITLE
feat(observability-pipeline): allow configuring metrics dataset

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.21-alpha
+version: 0.0.22-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.20-alpha
+version: 0.0.21-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -109,7 +109,7 @@ agent:
   executable: /otelcol-contrib
   description:
     identifying_attributes:
-      service.name: collector
+      service.name: {{ .Values.collector.serviceName }}
 
 
 storage:

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -109,7 +109,7 @@ agent:
   executable: /otelcol-contrib
   description:
     identifying_attributes:
-      service.name: {{ .Values.collector.serviceName }}
+      service.name: collector
 
 
 storage:

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             {{- end }}
             {{- if .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.enabled }}
             - name: TELEMETRY_METRICS_DATASET
-              {{- tpl (toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content) . | nindent 14 }}  
+              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content | nindent 14 }}  
             {{- end }}
             {{- if .Values.beekeeper.defaultEnv.LOG_LEVEL.enabled }}
             - name: LOG_LEVEL

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -77,6 +77,10 @@ spec:
             - name: TELEMETRY_KEY
               {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_KEY.content | nindent 14 }}  
             {{- end }}
+            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.enabled }}
+            - name: TELEMETRY_METRICS_DATASET
+              {{- tpl (toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content) . | nindent 14 }}  
+            {{- end }}
             {{- if .Values.beekeeper.defaultEnv.LOG_LEVEL.enabled }}
             - name: LOG_LEVEL
               {{- toYaml .Values.beekeeper.defaultEnv.LOG_LEVEL.content | nindent 14 }}  

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -58,7 +58,7 @@ beekeeper:
     TELEMETRY_METRICS_DATASET:
       enabled: true
       content:
-        value: "{{ .Values.collector.serviceName }}-metrics"
+        value: collector-metrics
     LOG_LEVEL:
       enabled: true
       content:
@@ -98,8 +98,6 @@ beekeeper:
 
 collector:
   enabled: true
-  # The service.name resource attribute value for this collector
-  serviceName: "collector"
   serviceAccount:
     create: true
     name: ""

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -55,6 +55,10 @@ beekeeper:
       enabled: true
       content:
         value: "${env:HONEYCOMB_API_KEY}"
+    TELEMETRY_METRICS_DATASET:
+      enabled: true
+      content:
+        value: "{{ .Values.collector.serviceName }}-metrics"
     LOG_LEVEL:
       enabled: true
       content:
@@ -94,6 +98,8 @@ beekeeper:
 
 collector:
   enabled: true
+  # The service.name resource attribute value for this collector
+  serviceName: "collector"
   serviceAccount:
     create: true
     name: ""

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -28,7 +28,7 @@ beekeeper:
   image:
     repository: "honeycombio/beekeeper"
     pullPolicy: IfNotPresent
-    tag: "0.0.1"
+    tag: "latest"
   endpoint: https://api.honeycomb.io:443
   pipelineInstallationID: ""
   team: ""


### PR DESCRIPTION
## Which problem is this PR solving?

https://app.asana.com/0/1208469935858869/1209598568289018

- adds support for new `TELEMETRY_METRICS_DATASET` env var to allow configuring how beekeeper injects the metrics dataset header for its clients.

## Short description of the changes

- add new env var
- add ability to set collector's `service.name` value

## How to verify that this has the expected result

Tested locally in kind

![image](https://github.com/user-attachments/assets/2abf293a-eed8-47a8-8ac6-a2eb87f8e61f)

