### PR TITLE
feat(observability-pipeline): enable opampsupervisor telemetry support

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.23-alpha
+version: 0.0.24-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -114,6 +114,10 @@ agent:
 
 storage:
   directory: /var/lib/otelcol/supervisor
+{{ if .Values.collector.opampsupervisor.telemetry.enabled }}
+telemetry:
+  {{- toYaml .Values.collector.opampsupervisor.telemetry.config | nindent 2}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -88,14 +88,21 @@ beekeeper:
               exporter:
                 otlp:
                   protocol: http/protobuf
-                  endpoint: http://{{ include "honeycomb-observability-pipeline.name" . }}-otelcol-deployment:4318
+                  endpoint: https://api.honeycomb.io:443
+                  headers:
+                  - name: "x-honeycomb-team"
+                    value: ${HONEYCOMB_API_KEY}
       logger_provider:
         processors:
           - batch:
               exporter:
                 otlp:
                   protocol: http/protobuf
-                  endpoint: http://{{ include "honeycomb-observability-pipeline.name" . }}-otelcol-deployment:4318
+                  endpoint: https://api.honeycomb.io:443
+                  headers:
+                  - name: "x-honeycomb-team"
+                    value: ${HONEYCOMB_API_KEY}
+
 
 collector:
   enabled: true
@@ -131,6 +138,36 @@ collector:
   extraEnvs: []
   volumes: []
   volumeMounts: []
+  opampsupervisor:
+    telemetry:
+      enabled: true
+      config:
+        traces:
+          propagators:
+            - tracecontext
+            - baggage
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://api.honeycomb.io:443
+                    headers:
+                    - name: "x-honeycomb-team"
+                      value: ${HONEYCOMB_API_KEY}
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://api.honeycomb.io:443
+                    headers:
+                      - name: "x-honeycomb-team"
+                        value: ${HONEYCOMB_API_KEY}
+        logs:
+          level: info
 
 
 otelcol-deployment:


### PR DESCRIPTION
## Which problem is this PR solving?

Adds ability to configure opampsupervisor telemetry

https://app.asana.com/0/1208469935858869/1209598578859278

## Short description of the changes

- add opampsupervisor telemetry support. on by default
- tweak beekeeper telemetry to go to honeycomb by default

## How to verify that this has the expected result

TODO