### PR TITLE
maint(htp): bump bindplane chart version

### DIFF
--- a/charts/htp/Chart.lock
+++ b/charts/htp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.26.3
-digest: sha256:8b4c561491c87a24b4e8e400beadaae5d378c2b3eb3ced277f8a6cf40ecfe9fe
-generated: "2025-01-23T09:51:36.228862-07:00"
+  version: 1.27.1
+digest: sha256:a5654c5984003090266b69cf9b3d814d0a9ce813e05f8a6ec2367195d6184e4e
+generated: "2025-03-10T16:22:45.235135309-07:00"

--- a/charts/htp/Chart.yaml
+++ b/charts/htp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp
 description: Honeycomb Telemetry Pipeline
 type: application
-version: 0.1.1
-appVersion: 1.85.0
+version: 0.1.2
+appVersion: 1.88.1
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm
@@ -13,6 +13,6 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
   - name: bindplane
-    version: "1.26.3"
+    version: "1.27.1"
     repository: "https://observiq.github.io/bindplane-op-helm"
     alias: htp


### PR DESCRIPTION
## Which problem is this PR solving?

We've fallen slightly behind on our bindplane version, and thus we're serving install instructions that install an older bindplane to customer clusters.