### PR TITLE
Update gh-pages README to match main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,17 @@
 # Honeycomb Helm Charts
 
 [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/helm-charts?color=success)](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md)
-[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/honeycomb)](https://artifacthub.io/packages/search?repo=honeycomb)
+[![CircleCI](https://circleci.com/gh/honeycombio/helm-charts.svg?style=shield)](https://circleci.com/gh/honeycombio/helm-charts)
 
 [Helm](https://helm.sh/) is a package manager for Kubernetes.
 You can use Helm for installing [Honeycomb](https://honeycomb.io) packages in your Kubernetes cluster.
 
 Packages:
-- [Honeycomb Kubernetes Agent](https://github.com/honeycombio/helm-charts/blob/main/charts/honeycomb)
-- [Honeycomb Refinery](https://github.com/honeycombio/helm-charts/blob/main/charts/refinery)
-- [Honeycomb Secure Tenancy Proxy](https://github.com/honeycombio/helm-charts/blob/main/charts/secure-tenancy)
-- [OpenTelemetry-Collector](https://github.com/honeycombio/helm-charts/blob/main/charts/opentelemetry-collector)
+- [Honeycomb Kubernetes Agent](./charts/honeycomb)
+- [Honeycomb Network Agent](./charts/network-agent)
+- [Honeycomb Refinery](./charts/refinery)
+- [Honeycomb Telemetry Pipeline](./charts/htp) (based on Bindplane)
+- [OpenTelemetry-Collector](./charts/opentelemetry-collector)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 You can use Helm for installing [Honeycomb](https://honeycomb.io) packages in your Kubernetes cluster.
 
 Packages:
-- [Honeycomb Kubernetes Agent](./charts/honeycomb)
-- [Honeycomb Network Agent](./charts/network-agent)
-- [Honeycomb Refinery](./charts/refinery)
-- [Honeycomb Telemetry Pipeline](./charts/htp) (based on Bindplane)
-- [OpenTelemetry-Collector](./charts/opentelemetry-collector)
+- [Honeycomb Kubernetes Agent](https://github.com/honeycombio/helm-charts/blob/main/charts/honeycomb)
+- [Honeycomb Network Agent](https://github.com/honeycombio/helm-charts/blob/main/charts/network-agent)
+- [Honeycomb Refinery](https://github.com/honeycombio/helm-charts/blob/main/charts/refinery)
+- [Honeycomb Telemetry Pipeline](https://github.com/honeycombio/helm-charts/blob/main/charts/htp) (based on Bindplane)
+- [OpenTelemetry-Collector](https://github.com/honeycombio/helm-charts/blob/main/charts/opentelemetry-collector)
 
 ## Installation
 


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

The README in the `gh-pages` branch (which displays at https://honeycombio.github.io/helm-charts/) is out of date.

## Short description of the changes

This makes it current with `main`.

## How to verify that this has the expected result
No PR previews for GitHub Pages! So just have to compare READMEs.
https://github.com/honeycombio/helm-charts/blob/jessica.update-gh-pages/README.md
should look the same as
https://github.com/honeycombio/helm-charts/blob/main/README.md
And the links on both should go to the same places.