### PR TITLE
maint(observability-pipeline): move required fields to root

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.27-alpha
+version: 0.0.28-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/README.md
+++ b/charts/observability-pipeline/README.md
@@ -32,7 +32,7 @@ To install the chart with the release name `my-pipeline`, run the following comm
 helm install my-pipeline honeycomb/observability-pipeline \
     --set team="my-team" \
     --set pipelineInstallationID="pipeline-intallation-id" \
-    --set publicMgmtKey="public-management-key-id"
+    --set publicMgmtAPIKey="public-management-key-id"
 ```
 
 To uninstall the chart:

--- a/charts/observability-pipeline/README.md
+++ b/charts/observability-pipeline/README.md
@@ -30,9 +30,9 @@ To install the chart with the release name `my-pipeline`, run the following comm
 
 ```shell
 helm install my-pipeline honeycomb/observability-pipeline \
-    --set beekeeper.team="my-team" \
-    --set beekeeper.pipelineInstallationID="pipeline-intallation-id" \
-    --set beekeeper.publicMgmtKey="public-management-key-id"
+    --set team="my-team" \
+    --set pipelineInstallationID="pipeline-intallation-id" \
+    --set publicMgmtKey="public-management-key-id"
 ```
 
 To uninstall the chart:

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -14,16 +14,16 @@
   {{- fail "beekeeper.endpoint must be set" }}
 {{- end }}
 
-{{- if (not .Values.beekeeper.pipelineInstallationID) }}
-  {{- fail "beekeeper.pipelineInstallationID must be set" }}
+{{- if (not .Values.pipelineInstallationID) }}
+  {{- fail "pipelineInstallationID must be set" }}
 {{- end }}
 
-{{- if (not .Values.beekeeper.team) }}
-  {{- fail "beekeeper.team must be set" }}
+{{- if (not .Values.team) }}
+  {{- fail "team must be set" }}
 {{- end }}
 
-{{- if (not .Values.beekeeper.publicMgmtKey) }}
-  {{- fail "beekeeper.publicMgmtKey must be set" }}
+{{- if (not .Values.publicMgmtKey) }}
+  {{- fail "publicMgmtKey must be set" }}
 {{- end }}
 
 {{- if (not .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content) }}

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -22,8 +22,8 @@
   {{- fail "team must be set" }}
 {{- end }}
 
-{{- if (not .Values.publicMgmtKey) }}
-  {{- fail "publicMgmtKey must be set" }}
+{{- if (not .Values.publicMgmtAPIKey) }}
+  {{- fail "publicMgmtAPIKey must be set" }}
 {{- end }}
 
 {{- if (not .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content) }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -55,15 +55,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.beekeeper.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
               value: {{ .Values.beekeeper.endpoint }}
             - name: HONEYCOMB_TEAM
-              value: {{ .Values.beekeeper.team }}
+              value: {{ .Values.team }}
             - name: HONEYCOMB_INSTALLATION_ID
-              value: {{ .Values.beekeeper.pipelineInstallationID }}
+              value: {{ .Values.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY
-              value: {{ .Values.beekeeper.publicMgmtKey }}
+              value: {{ .Values.publicMgmtKey }}
             - name: HONEYCOMB_MGMT_API_SECRET
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content | nindent 14 }}  
             - name: HONEYCOMB_API_KEY

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: HONEYCOMB_INSTALLATION_ID
               value: {{ .Values.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY
-              value: {{ .Values.publicMgmtKey }}
+              value: {{ .Values.publicMgmtAPIKey }}
             - name: HONEYCOMB_MGMT_API_SECRET
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content | nindent 14 }}  
             - name: HONEYCOMB_API_KEY

--- a/charts/observability-pipeline/templates/collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/collector-deployment.yaml
@@ -51,7 +51,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.beekeeper.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             {{- if .Values.collector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.collector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,6 +1,6 @@
 pipelineInstallationID: ""
 team: ""
-publicMgmtKey: ""
+publicMgmtAPIKey: ""
 
 refinery:
   image:

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,4 +1,6 @@
-name: honeycomb-observability-pipeline
+pipelineInstallationID: ""
+team: ""
+publicMgmtKey: ""
 
 refinery:
   image:
@@ -32,9 +34,6 @@ beekeeper:
     pullPolicy: IfNotPresent
     tag: "latest"
   endpoint: https://api.honeycomb.io:443
-  pipelineInstallationID: ""
-  team: ""
-  publicMgmtKey: ""
   persistentVolumeClaimName: ""
   defaultEnv:
     HONEYCOMB_MGMT_API_SECRET:


### PR DESCRIPTION
## Which problem is this PR solving?

To simplify the required chart config, move the team, pipelineInstallatinID, and management key to the root.

## Short description of the changes

- move settings to root
- update templates
- update README

## How to verify that this has the expected result

Local templating
