### PR TITLE
feat: add service.namespace to supervisor config

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.28-alpha
+version: 0.0.29-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -111,6 +111,7 @@ agent:
   description:
     identifying_attributes:
       service.name: collector
+      service.namespace: htp.collector
 
 storage:
   directory: /var/lib/otelcol/supervisor


### PR DESCRIPTION
## Which problem is this PR solving?

This adds the service.namespace field to the opampsupervisor configuration.
