### PR TITLE
fix(observability-pipeline): reuse primaryCollector service name

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.34-alpha
+version: 0.0.35-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -110,7 +110,7 @@ agent:
   config_apply_timeout: 10s
   description:
     identifying_attributes:
-      service.name: primary-collector
+      service.name: {{ .Values.primaryCollector.serviceName }}
       service.namespace: htp.collector
 
 storage:

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -78,7 +78,7 @@ spec:
             {{- end }}
             {{- if .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.enabled }}
             - name: TELEMETRY_METRICS_DATASET
-              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content | nindent 14 }}  
+              {{- tpl (toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content) . | nindent 14 }}  
             {{- end }}
             {{- if .Values.beekeeper.defaultEnv.LOG_LEVEL.enabled }}
             - name: LOG_LEVEL

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -59,7 +59,7 @@ beekeeper:
     TELEMETRY_METRICS_DATASET:
       enabled: true
       content:
-        value: collector-metrics
+        value: "{{ .Values.primaryCollector.serviceName }}-metrics"
     LOG_LEVEL:
       enabled: true
       content:
@@ -112,6 +112,7 @@ beekeeper:
 
 
 primaryCollector:
+  serviceName: "primary-collector"
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
## Which problem is this PR solving?

fixes an issue where the primary collector service name was not used for its metrics data

## How to verify that this has the expected result

helm template