### PR TITLE
fix(bindplane): update bindplane chart.lock version

### DIFF
--- a/charts/htp/Chart.lock
+++ b/charts/htp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.27.1
+  version: 1.28.0
 digest: sha256:a5654c5984003090266b69cf9b3d814d0a9ce813e05f8a6ec2367195d6184e4e
 generated: "2025-03-10T16:22:45.235135309-07:00"

--- a/charts/htp/Chart.lock
+++ b/charts/htp/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
   version: 1.28.0
-digest: sha256:a5654c5984003090266b69cf9b3d814d0a9ce813e05f8a6ec2367195d6184e4e
-generated: "2025-03-10T16:22:45.235135309-07:00"
+digest: sha256:15057625b9685c50666a6fe6d4bc77d70ad5d0c4a4dc03b4e0f4c9f9d241cc0b
+generated: "2025-04-07T14:15:06.343445-07:00"


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
Fix the broken bindplane release deploy


## Short description of the changes
Update bindplane chart.lock to match chart version

## How to verify that this has the expected result
Circle job passes