### PR TITLE
maint: Remove unused team variable

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.36-alpha
+version: 0.0.37-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/README.md
+++ b/charts/observability-pipeline/README.md
@@ -30,7 +30,6 @@ To install the chart with the release name `my-pipeline`, run the following comm
 
 ```shell
 helm install my-pipeline honeycomb/observability-pipeline \
-    --set team="my-team" \
     --set pipelineInstallationID="pipeline-intallation-id" \
     --set publicMgmtAPIKey="public-management-key-id"
 ```

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -18,10 +18,6 @@
   {{- fail "pipelineInstallationID must be set" }}
 {{- end }}
 
-{{- if (not .Values.team) }}
-  {{- fail "team must be set" }}
-{{- end }}
-
 {{- if (not .Values.publicMgmtAPIKey) }}
   {{- fail "publicMgmtAPIKey must be set" }}
 {{- end }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -58,8 +58,6 @@ spec:
               value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
               value: {{ .Values.beekeeper.endpoint }}
-            - name: HONEYCOMB_TEAM
-              value: {{ .Values.team }}
             - name: HONEYCOMB_INSTALLATION_ID
               value: {{ .Values.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,5 +1,4 @@
 pipelineInstallationID: ""
-team: ""
 publicMgmtAPIKey: ""
 
 refinery:


### PR DESCRIPTION
## Which problem is this PR solving?

Remove unused team variable now beekeeper doesn't [use it anymore](https://github.com/honeycombio/beekeeper/pull/87).

## Short description of the changes

- remove team variable, usage in beekeeper values and validation in notes.txt