### PR TITLE
feat(refinery): Make it easy to set eu1 urls

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.15.5
+version: 2.16.0
 appVersion: 2.9.4
 keywords:
   - refinery

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -204,15 +204,15 @@ OTelTracing:
 
 {{- define "refinery.localConfig" -}}
 Network:
-  HoneycombAPI: http://localhost:8081
+  HoneycombAPI: http://host.docker.internal:8081
 HoneycombLogger:
-  APIHost: http://localhost:8081
+  APIHost: http://host.docker.internal:8081
 LegacyMetrics:
-  APIHost: http://localhost:8081
+  APIHost: http://host.docker.internal:8081
 OTelMetrics:
-  APIHost: http://localhost:8081
+  APIHost: http://host.docker.internal:8081
 OTelTracing:
-  APIHost: http://localhost:8081
+  APIHost: http://host.docker.internal:8081
 {{- end }}
 
 {{/*

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -112,12 +112,108 @@ Build config file for Refinery
 {{-     end }}
 {{-   end }}   
 {{- end }}
+{{- if eq .Values.region "production-eu" }}
+{{- $config = mustMergeOverwrite (include "refinery.productionEUConfig" .Values | fromYaml) $config }}
+{{- end }}
+{{- if eq .Values.region "dogfood-eu" }}
+{{- $config = mustMergeOverwrite (include "refinery.dogfoodEUConfig" .Values | fromYaml) $config }}
+{{- end }}
+{{- if eq .Values.region "kibble-eu" }}
+{{- $config = mustMergeOverwrite (include "refinery.kibbleEUConfig" .Values | fromYaml) $config }}
+{{- end }}
+{{- if eq .Values.region "dogfood" }}
+{{- $config = mustMergeOverwrite (include "refinery.dogfoodConfig" .Values | fromYaml) $config }}
+{{- end }}
+{{- if eq .Values.region "kibble" }}
+{{- $config = mustMergeOverwrite (include "refinery.kibbleConfig" .Values | fromYaml) $config }}
+{{- end }}
+{{- if eq .Values.region "local" }}
+{{- $config = mustMergeOverwrite (include "refinery.localConfig" .Values | fromYaml) $config }}
+{{- end }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
 
 {{- define "refinery.DebugServiceAddr" -}}
 {{- printf "localhost:%v" .Values.debug.port }}
 {{- end}}
+
+{{- define "refinery.productionEUConfig" -}}
+Network:
+  HoneycombAPI: https://api.eu1.honeycomb.io
+HoneycombLogger:
+  APIHost: https://api.eu1.honeycomb.io
+LegacyMetrics:
+  APIHost: https://api.eu1.honeycomb.io
+OTelMetrics:
+  APIHost: https://api.eu1.honeycomb.io
+OTelTracing:
+  APIHost: https://api.eu1.honeycomb.io
+{{- end }}
+
+{{- define "refinery.dogfoodEUConfig" -}}
+Network:
+  HoneycombAPI: https://api.dogfood-eu1.honeycomb.io
+HoneycombLogger:
+  APIHost: https://api.dogfood-eu1.honeycomb.io
+LegacyMetrics:
+  APIHost: https://api.dogfood-eu1.honeycomb.io
+OTelMetrics:
+  APIHost: https://api.dogfood-eu1.honeycomb.io
+OTelTracing:
+  APIHost: https://api.dogfood-eu1.honeycomb.io
+{{- end }}
+
+{{- define "refinery.kibbleEUConfig" -}}
+Network:
+  HoneycombAPI: https://api.kibble-eu1.honeycomb.io
+HoneycombLogger:
+  APIHost: https://api.kibble-eu1.honeycomb.io
+LegacyMetrics:
+  APIHost: https://api.kibble-eu1.honeycomb.io
+OTelMetrics:
+  APIHost: https://api.kibble-eu1.honeycomb.io
+OTelTracing:
+  APIHost: https://api.kibble-eu1.honeycomb.io
+{{- end }}
+
+{{- define "refinery.dogfoodConfig" -}}
+Network:
+  HoneycombAPI: https://api-dogfood.honeycomb.io
+HoneycombLogger:
+  APIHost: https://api-dogfood.honeycomb.io
+LegacyMetrics:
+  APIHost: https://api-dogfood.honeycomb.io
+OTelMetrics:
+  APIHost: https://api-dogfood.honeycomb.io
+OTelTracing:
+  APIHost: https://api-dogfood.honeycomb.io
+{{- end }}
+
+{{- define "refinery.kibbleConfig" -}}
+Network:
+  HoneycombAPI: https://api-kibble.honeycomb.io
+HoneycombLogger:
+  APIHost: https://api-kibble.honeycomb.io
+LegacyMetrics:
+  APIHost: https://api-kibble.honeycomb.io
+OTelMetrics:
+  APIHost: https://api-kibble.honeycomb.io
+OTelTracing:
+  APIHost: https://api-kibble.honeycomb.io
+{{- end }}
+
+{{- define "refinery.localConfig" -}}
+Network:
+  HoneycombAPI: http://localhost:8081
+HoneycombLogger:
+  APIHost: http://localhost:8081
+LegacyMetrics:
+  APIHost: http://localhost:8081
+OTelMetrics:
+  APIHost: http://localhost:8081
+OTelTracing:
+  APIHost: http://localhost:8081
+{{- end }}
 
 {{/*
 Build rules file for Refinery

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -110,7 +110,7 @@ Build config file for Refinery
 {{-     if not $debugServiceAddr }}
 {{-       $_ := set $debugging "DebugServiceAddr" (include "refinery.DebugServiceAddr" .) }}
 {{-     end }}
-{{-   end }}   
+{{-   end }}
 {{- end }}
 {{- if eq .Values.region "production-eu" }}
 {{- $config = mustMergeOverwrite (include "refinery.productionEUConfig" .Values | fromYaml) $config }}

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -115,20 +115,8 @@ Build config file for Refinery
 {{- if eq .Values.region "production-eu" }}
 {{- $config = mustMergeOverwrite (include "refinery.productionEUConfig" .Values | fromYaml) $config }}
 {{- end }}
-{{- if eq .Values.region "dogfood-eu" }}
-{{- $config = mustMergeOverwrite (include "refinery.dogfoodEUConfig" .Values | fromYaml) $config }}
-{{- end }}
-{{- if eq .Values.region "kibble-eu" }}
-{{- $config = mustMergeOverwrite (include "refinery.kibbleEUConfig" .Values | fromYaml) $config }}
-{{- end }}
-{{- if eq .Values.region "dogfood" }}
-{{- $config = mustMergeOverwrite (include "refinery.dogfoodConfig" .Values | fromYaml) $config }}
-{{- end }}
-{{- if eq .Values.region "kibble" }}
-{{- $config = mustMergeOverwrite (include "refinery.kibbleConfig" .Values | fromYaml) $config }}
-{{- end }}
-{{- if eq .Values.region "local" }}
-{{- $config = mustMergeOverwrite (include "refinery.localConfig" .Values | fromYaml) $config }}
+{{- if eq .Values.region "custom" }}
+{{- $config = mustMergeOverwrite (include "refinery.customConfig" .Values | fromYaml) $config }}
 {{- end }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
@@ -150,69 +138,17 @@ OTelTracing:
   APIHost: https://api.eu1.honeycomb.io
 {{- end }}
 
-{{- define "refinery.dogfoodEUConfig" -}}
+{{- define "refinery.customConfig" -}}
 Network:
-  HoneycombAPI: https://api.dogfood-eu1.honeycomb.io
+  HoneycombAPI: {{ .Values.customEndpoint }}
 HoneycombLogger:
-  APIHost: https://api.dogfood-eu1.honeycomb.io
+  APIHost: {{ .Values.customEndpoint }}
 LegacyMetrics:
-  APIHost: https://api.dogfood-eu1.honeycomb.io
+  APIHost: {{ .Values.customEndpoint }}
 OTelMetrics:
-  APIHost: https://api.dogfood-eu1.honeycomb.io
+  APIHost: {{ .Values.customEndpoint }}
 OTelTracing:
-  APIHost: https://api.dogfood-eu1.honeycomb.io
-{{- end }}
-
-{{- define "refinery.kibbleEUConfig" -}}
-Network:
-  HoneycombAPI: https://api.kibble-eu1.honeycomb.io
-HoneycombLogger:
-  APIHost: https://api.kibble-eu1.honeycomb.io
-LegacyMetrics:
-  APIHost: https://api.kibble-eu1.honeycomb.io
-OTelMetrics:
-  APIHost: https://api.kibble-eu1.honeycomb.io
-OTelTracing:
-  APIHost: https://api.kibble-eu1.honeycomb.io
-{{- end }}
-
-{{- define "refinery.dogfoodConfig" -}}
-Network:
-  HoneycombAPI: https://api-dogfood.honeycomb.io
-HoneycombLogger:
-  APIHost: https://api-dogfood.honeycomb.io
-LegacyMetrics:
-  APIHost: https://api-dogfood.honeycomb.io
-OTelMetrics:
-  APIHost: https://api-dogfood.honeycomb.io
-OTelTracing:
-  APIHost: https://api-dogfood.honeycomb.io
-{{- end }}
-
-{{- define "refinery.kibbleConfig" -}}
-Network:
-  HoneycombAPI: https://api-kibble.honeycomb.io
-HoneycombLogger:
-  APIHost: https://api-kibble.honeycomb.io
-LegacyMetrics:
-  APIHost: https://api-kibble.honeycomb.io
-OTelMetrics:
-  APIHost: https://api-kibble.honeycomb.io
-OTelTracing:
-  APIHost: https://api-kibble.honeycomb.io
-{{- end }}
-
-{{- define "refinery.localConfig" -}}
-Network:
-  HoneycombAPI: http://host.docker.internal:8081
-HoneycombLogger:
-  APIHost: http://host.docker.internal:8081
-LegacyMetrics:
-  APIHost: http://host.docker.internal:8081
-OTelMetrics:
-  APIHost: http://host.docker.internal:8081
-OTelTracing:
-  APIHost: http://host.docker.internal:8081
+  APIHost: {{ .Values.customEndpoint }}
 {{- end }}
 
 {{/*

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -1,9 +1,7 @@
 # Default values for refinery.
 
 # This setting configures the default endpoints. All configuration endpoints can still be set and will take precedence.
-#
 # The default value is ''. When unset, Refinery's default values will be used for any unconfigured endpoints.
-#
 # Other valid values are:
 #  - production-eu
 #  - dogfood
@@ -13,7 +11,6 @@
 #  - local
 # 
 # When `production-eu` is set, the refinery config is updated to include:
-#
 #   Network:
 #     HoneycombAPI: https://api.eu1.honeycomb.io
 #   HoneycombLogger:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -4,11 +4,6 @@
 # The default value is ''. When unset, Refinery's default values will be used for any unconfigured endpoints.
 # Other valid values are:
 #  - production-eu
-#  - dogfood
-#  - dogfood-eu
-#  - kibble
-#  - kibble-eu
-#  - local
 #
 # When `production-eu` is set, the refinery config is updated to include:
 #   Network:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -4,6 +4,7 @@
 # The default value is ''. When unset, Refinery's default values will be used for any unconfigured endpoints.
 # Other valid values are:
 #  - production-eu
+#  - custom
 #
 # When `production-eu` is set, the refinery config is updated to include:
 #   Network:
@@ -20,6 +21,8 @@
 # Any values you've configured will take precedence.
 # Reminder that LegacyMetrics, OTelMetrics, and OTelTracing still need to be enabled to be used.
 region: ""
+# When region=custom this field's value will be used to set Refinery's various endpoints
+customEndpoint: ""
 
 # The Refinery configuration.
 # This section allows setting all Refinery configuration options.

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -1,5 +1,34 @@
 # Default values for refinery.
 
+# This setting configures the default endpoints. All configuration endpoints can still be set and will take precedence.
+#
+# The default value is ''. When unset, Refinery's default values will be used for any unconfigured endpoints.
+#
+# Other valid values are:
+#  - production-eu
+#  - dogfood
+#  - dogfood-eu
+#  - kibble
+#  - kibble-eu
+#  - local
+# 
+# When `production-eu` is set, the refinery config is updated to include:
+#
+#   Network:
+#     HoneycombAPI: https://api.eu1.honeycomb.io
+#   HoneycombLogger:
+#     APIHost: https://api.eu1.honeycomb.io
+#   LegacyMetrics:
+#     APIHost: https://api.eu1.honeycomb.io
+#   OTelMetrics:
+#     APIHost: https://api.eu1.honeycomb.io
+#   OTelTracing:
+#     APIHost: https://api.eu1.honeycomb.io
+#
+# Any values you've configured will take precedence.
+# Reminder that LegacyMetrics, OTelMetrics, and OTelTracing still need to be enabled to be used.
+region: ""
+
 # The Refinery configuration.
 # This section allows setting all Refinery configuration options.
 # Configuration values set here by default have been set based on the requirements of the chart and Kubernetes.

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -9,7 +9,7 @@
 #  - kibble
 #  - kibble-eu
 #  - local
-# 
+#
 # When `production-eu` is set, the refinery config is updated to include:
 #   Network:
 #     HoneycombAPI: https://api.eu1.honeycomb.io


### PR DESCRIPTION
## Which problem is this PR solving?

Right now eu customer need to manually set a couple refinery configuration endpoints to point to eu honeycomb instead of prod. That is kind of annoying. This PR allows the chart to automatically set those fields based on a flag.

## Short description of the changes
- add new `region` setting that will automatically configure refinery's endpoints based on the value
- Add comments

## How to verify that this has the expected result
tested locally using `helm template`
