### PR TITLE
feat(refinery): allow setting region from global

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.16.0
+version: 2.16.1
 appVersion: 2.9.4
 keywords:
   - refinery

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -112,7 +112,7 @@ Build config file for Refinery
 {{-     end }}
 {{-   end }}
 {{- end }}
-{{- if eq .Values.region "production-eu" }}
+{{- if eq (include "refinery.region" .) "production-eu" }}
 {{- $config = mustMergeOverwrite (include "refinery.productionEUConfig" .Values | fromYaml) $config }}
 {{- end }}
 {{- if eq .Values.region "custom" }}
@@ -124,6 +124,10 @@ Build config file for Refinery
 {{- define "refinery.DebugServiceAddr" -}}
 {{- printf "localhost:%v" .Values.debug.port }}
 {{- end}}
+
+{{- define "refinery.region" -}}
+{{- default "" (default (.Values.global).region .Values.region) }}
+{{- end }}
 
 {{- define "refinery.productionEUConfig" -}}
 Network:


### PR DESCRIPTION
## Which problem is this PR solving?

when using the region feature in the refinery chart as a subchart the parent chart can only pass a value into the subchart via `global`.

## Short description of the changes
- updates the chart to support `global.region`, with `region` taking precedence if it is set.

## How to verify that this has the expected result

local templating
