### PR TITLE
feat(observability-pipeline): allow setting region

### DIFF
--- a/charts/observability-pipeline/Chart.lock
+++ b/charts/observability-pipeline/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: refinery
   repository: https://honeycombio.github.io/helm-charts
-  version: 2.15.3
-digest: sha256:9c8e7397c50102335e2c700f63dc902d355c52f2a1681e2bd043fe417716b23c
-generated: "2025-03-17T10:55:21.605315-06:00"
+  version: 2.16.1
+digest: sha256:a75cc28275edbfe64581f0c1ea9ad3c4a809ad1cb42f01e137fdb3fa87d244c6
+generated: "2025-04-11T12:19:55.20025-06:00"

--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -22,5 +22,5 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
 - name: refinery
-  version: 2.15.3
+  version: 2.16.1
   repository: "https://honeycombio.github.io/helm-charts"

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -10,8 +10,8 @@
   {{- fail "beekeeper.image.tag must be set" }}
 {{- end }}
 
-{{- if (not .Values.beekeeper.endpoint) }}
-  {{- fail "beekeeper.endpoint must be set" }}
+{{- if and (not .Values.global.region) (not .Values.beekeeper.endpoint) }}
+  {{- fail "global.region or beekeeper.endpoint must be set" }}
 {{- end }}
 
 {{- if (not .Values.pipelineInstallationID) }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -57,7 +57,7 @@ spec:
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
-              value: {{ .Values.beekeeper.endpoint }}
+              value: {{ include "honeycomb-observability-pipeline.beekeeper.endpoint" . }}
             - name: HONEYCOMB_INSTALLATION_ID
               value: {{ .Values.pipelineInstallationID }}
             - name: HONEYCOMB_MGMT_API_KEY
@@ -68,7 +68,7 @@ spec:
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
             {{- if .Values.beekeeper.defaultEnv.TELEMETRY_ENDPOINT.enabled }}
             - name: TELEMETRY_ENDPOINT
-              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_ENDPOINT.content | nindent 14 }}  
+              {{- include "honeycomb-observability-pipeline.beekeeper.telemetryEndpoint" . | indent 14 }}  
             {{- end }}
             {{- if .Values.beekeeper.defaultEnv.TELEMETRY_KEY.enabled }}
             - name: TELEMETRY_KEY

--- a/charts/observability-pipeline/templates/primary-collector-configmap.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-configmap.yaml
@@ -4,8 +4,8 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-primary-collector
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipelineprimaryCollector.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.primaryCollector.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
 data:
   config: |
-  {{- include "honeycomb-observability-pipelineprimaryCollectorConfig" . | nindent 4 -}}
+  {{- include "honeycomb-observability-pipeline.primaryCollector.config" . | nindent 4 -}}

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -4,24 +4,24 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-primary-collector
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipelineprimaryCollector.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.primaryCollector.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
 spec:
   replicas: {{ .Values.primaryCollector.replicaCount }}
   selector:
     matchLabels:
-      {{- include "honeycomb-observability-pipelineprimaryCollector.selectorLabels" . | nindent 6 }}
+      {{- include "honeycomb-observability-pipeline.primaryCollector.selectorLabels" . | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       annotations:
-        {{- include "honeycomb-observability-pipelineprimaryCollector.configTemplateChecksumAnnotation" . | nindent 8 }}
+        {{- include "honeycomb-observability-pipeline.primaryCollector.configTemplateChecksumAnnotation" . | nindent 8 }}
       labels:
-        {{- include "honeycomb-observability-pipelineprimaryCollector.selectorLabels" . | nindent 8 }}
+        {{- include "honeycomb-observability-pipeline.primaryCollector.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: collector
     spec:
-      serviceAccountName: {{ include "honeycomb-observability-pipelineprimaryCollector.serviceAccountName" . }}
+      serviceAccountName: {{ include "honeycomb-observability-pipeline.primaryCollector.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.primaryCollector.image.repository }}:{{ .Values.primaryCollector.image.tag }}"

--- a/charts/observability-pipeline/templates/primary-collector-service.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-service.yaml
@@ -5,12 +5,12 @@ metadata:
   name: {{ include "honeycomb-observability-pipeline.fullname" . }}-primary-collector
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipelineprimaryCollector.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.primaryCollector.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
 spec:
   type: ClusterIP
   ports:
     {{- toYaml .Values.primaryCollector.service.ports | nindent 4 }}
   selector:
-    {{- include "honeycomb-observability-pipelineprimaryCollector.selectorLabels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.primaryCollector.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/observability-pipeline/templates/primary-collector-serviceaccount.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-serviceaccount.yaml
@@ -2,9 +2,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "honeycomb-observability-pipelineprimaryCollector.serviceAccountName" . }}
+  name: {{ include "honeycomb-observability-pipeline.primaryCollector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "honeycomb-observability-pipelineprimaryCollector.labels" . | nindent 4 }}
+    {{- include "honeycomb-observability-pipeline.primaryCollector.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
 {{- end }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,6 +1,9 @@
 pipelineInstallationID: ""
 publicMgmtAPIKey: ""
 
+global:
+  region: ""
+
 refinery:
   image:
     repository: "honeycombio/refinery"
@@ -32,7 +35,7 @@ beekeeper:
     repository: "honeycombio/beekeeper"
     pullPolicy: IfNotPresent
     tag: "latest"
-  endpoint: https://api.honeycomb.io:443
+  endpoint: ""
   persistentVolumeClaimName: ""
   defaultEnv:
     HONEYCOMB_MGMT_API_SECRET:
@@ -49,8 +52,6 @@ beekeeper:
             key: api-key
     TELEMETRY_ENDPOINT:
       enabled: true
-      content:
-        value: https://api.honeycomb.io:443
     TELEMETRY_KEY:
       enabled: true
       content:
@@ -147,7 +148,7 @@ primaryCollector:
   opampsupervisor:
     telemetry:
       enabled: true
-      defaultEndpoint: https://api.honeycomb.io:443
+      defaultEndpoint: ""
       defaultServiceName: opamp-supervisor
       config:
         resource:
@@ -159,7 +160,7 @@ primaryCollector:
                 exporter:
                   otlp:
                     protocol: http/protobuf
-                    endpoint: '{{ .Values.primaryCollector.opampsupervisor.telemetry.defaultEndpoint }}'
+                    endpoint: '{{ include "honeycomb-observability-pipeline.primaryCollector.opampsupervisor.telemetry.defaultEndpoint" . }}'
                     headers:
                     - name: "x-honeycomb-team"
                       value: ${HONEYCOMB_API_KEY}


### PR DESCRIPTION
## Which problem is this PR solving?

There are a lot of urls to configure if you're not going to prod-us1. This PR adds a new `global.region` option that our EU customers can use to easily swap all the urls to point to the appropriate `-eu1` version instead of the US version.

## Short description of the changes
- add `global.region` setting in values.yaml
- update refinery chart to be able to use its `region` feature
- update beekeeper.endpoint to factor in region
- update beekeeper TELEMETRY_ENDPOINT to factor in region
- update primaryCollector opampsupervisor telemetry to factor in region
- fix some incorrectly named templates

## How to verify that this has the expected result
local templating
