### PR TITLE
fix(observability-pipeline): fix default refinery opamp endpoint

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.39-alpha
+version: 0.0.40-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -193,3 +193,14 @@ Calculate primary collector opampsupervisor default endpoint for telemetry
 {{- default "https://api.honeycomb.io" .Values.primaryCollector.opampsupervisor.telemetry.defaultEndpoint }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the beekeeper service for refinery
+*/}}
+{{- define "honeycomb-observability-pipeline.beekeeperName" -}}
+{{- if contains "observability-pipeline" .Release.Name }}
+{{- printf "%s-%s" .Release.Name "beekeeper" | trunc 63 | trimSuffix "-"  }}
+{{- else }}
+{{- printf "%s-%s-%s" .Release.Name "observability-pipeline" "beekeeper" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -11,7 +11,7 @@ refinery:
   config:
     OpAMP:
       Enabled: true
-      Endpoint: "ws://{{ include \"honeycomb-observability-pipeline.name\" . }}-beekeeper:4320/v1/opamp"
+      Endpoint: "ws://{{ include \"honeycomb-observability-pipeline.name\" . }}-observability-pipeline-beekeeper:4320/v1/opamp"
       RecordUsage: false
     PrometheusMetrics:
       Enabled: false

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -11,7 +11,7 @@ refinery:
   config:
     OpAMP:
       Enabled: true
-      Endpoint: "ws://{{ include \"honeycomb-observability-pipeline.name\" . }}-observability-pipeline-beekeeper:4320/v1/opamp"
+      Endpoint: "ws://{{ include \"honeycomb-observability-pipeline.beekeeperName\" . }}:4320/v1/opamp"
       RecordUsage: false
     PrometheusMetrics:
       Enabled: false


### PR DESCRIPTION
## Which problem is this PR solving?

The chart is currently defaulting the endpoint to `"ws://<release name>-beekeeper:4320/v1/opamp"`, but the default service name for beekeeper is `<release name>-observability-pipeline-beekeeper`.

## Short description of the changes

- fix the default opamp endpoint for refinery to point to the default beekeeper service

## How to verify that this has the expected result

tested locally in kind
