### PR TITLE
feat(observability-pipeline): add json schema for the chart

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.41-alpha
+version: 0.0.42-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/values.schema.json
+++ b/charts/observability-pipeline/values.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "title": "Values",
+  "additionalProperties": false,
+  "properties": {
+    "enabled": {
+      "type": "boolean"
+    },
+    "global": {
+      "type": "object"
+    },
+    "pipelineInstallationID": {
+      "type": "string"
+    },
+    "publicMgmtAPIKey": {
+      "type": "string"
+    },
+    "refinery": {
+      "type": "object"      
+    },
+    "beekeeper": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "resources": {
+          "type": "object"
+        },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "endpoint": {
+          "type": "string"
+        },
+        "persistentVolumeClaimName": {
+          "type": "string"
+        },
+        "defaultEnv": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HONEYCOMB_MGMT_API_SECRET": {
+              "type": "object"
+            },
+            "HONEYCOMB_API_KEY": {
+              "type": "object"
+            },
+            "TELEMETRY_ENDPOINT": {
+              "type": "object"
+            },
+            "TELEMETRY_KEY": {
+              "type": "object"
+            },
+            "TELEMETRY_METRICS_DATASET": {
+              "type": "object"
+            },
+            "LOG_LEVEL": {
+              "type": "object"
+            },
+            "HONEYCOMB_CONFIGURATION_KEY": {
+              "type": "object"
+            }
+          }
+        },
+        "extraEnvs": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "volumeMounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "telemetry": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "config": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    "primaryCollector": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "serviceName": {
+          "type": "string"
+        },
+        "serviceAccount": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "ports": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "port": {
+                    "type": "integer"
+                  },
+                  "targetPort": {
+                    "type": "integer"
+                  },
+                  "protocol": {
+                    "type": "string"
+                  },
+                  "appProtocol": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "replicaCount": {
+          "type": "integer"
+        },
+        "image": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "defaultEnv": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "HONEYCOMB_API_KEY": {
+              "type": "object"
+            }
+          }          
+        },
+        "extraEnvs": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "volumes": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "volumeMounts": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "opampsupervisor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "telemetry": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "defaultEndpoint": {
+                  "type": "string"
+                },
+                "defaultServiceName": {
+                  "type": "string"
+                },
+                "config": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,9 +1,46 @@
+# The ID of your pipeline installation.
+# This can be found on the Pipeline Installations page in the Honeycomb UI.
 pipelineInstallationID: ""
+
+# The public ID of your Honeycomb Management API key.
+# See https://docs.honeycomb.io/configure/teams/manage-api-keys/#find-management-api-keys for more details.
 publicMgmtAPIKey: ""
 
 global:
+  # This setting configures the default endpoints. All endpoints can still be configured and will take precedence.
+  # The default value is '' (unset). When unset, U.S. values will be used for any unconfigured endpoints.
+  # Other valid values are:
+  #  - production-eu
+  #
+  # When 'production-eu' is set, the following settings are configured:
+  #  refinery:
+  #    config:
+  #      Network:
+  #        HoneycombAPI: https://api.eu1.honeycomb.io
+  #      HoneycombLogger:
+  #        APIHost: https://api.eu1.honeycomb.io
+  #      LegacyMetrics:
+  #        APIHost: https://api.eu1.honeycomb.io
+  #      OTelMetrics:
+  #        APIHost: https://api.eu1.honeycomb.io
+  #      OTelTracing:
+  #        APIHost: https://api.eu1.honeycomb.io
+  #  beekeeker:
+  #    endpoint: https://api.eu1.honeycomb.io
+  #    defaultEnv:
+  #      TELEMETRY_ENDPOINT:
+  #        content:
+  #          value: https://api.eu1.honeycomb.io
+  #  primaryCollector:
+  #    opampsupervisor
+  #      telemetry:
+  #        defaultEndpoint: https://api.eu1.honeycomb.io
+  #
+  # Any values you've configured will take precedence.
   region: ""
 
+# Configuration options for Refinery.
+# For a complete list of configuration options see https://github.com/honeycombio/helm-charts/tree/main/charts/refinery#configuration.
 refinery:
   image:
     repository: "honeycombio/refinery"
@@ -26,17 +63,18 @@ refinery:
           name: honeycomb-observability-pipeline
           key: api-key
 
+# Configuration options for Beekeeper.
 beekeeper:
-  resources: {}
-  serviceAccount:
-    create: true
-    name: ""
   image:
     repository: "honeycombio/beekeeper"
     pullPolicy: IfNotPresent
     tag: "latest"
+
+  # The Hnoeycomb API endpoint Beekeeper should use.
+  # When unset (the default), Beekeeper will use https://api.honeycomb.io
   endpoint: ""
-  persistentVolumeClaimName: ""
+
+  # Allows configuring Beekeeper environment variables. 
   defaultEnv:
     HONEYCOMB_MGMT_API_SECRET:
       content:
@@ -64,6 +102,7 @@ beekeeper:
       enabled: true
       content:
         value: "info"
+    # Enabled this env var if you want Beekeeper to create markers during rollouts.
     HONEYCOMB_CONFIGURATION_KEY:
       enabled: false
       content:
@@ -72,10 +111,29 @@ beekeeper:
             name: honeycomb-observability-pipeline
             key: configuration-key
   extraEnvs: []
+
+  # Resource limits & requests.
+  # It is HIGHLY recommended to set resource limits.
+  # resources:
+  #   limits:
+  #     cpu: 50m
+  #     memory: 50Mi
+  resources: {}
+
+  serviceAccount:
+    create: true
+    # Name of the service account to use if not creating a new one.
+    name: ""
+
+  persistentVolumeClaimName: ""
   volumes: []
   volumeMounts: []
+
+  # Settings for Beekeeper's internal telemetry.
   telemetry:
     enabled: true
+
+    # Beekeeper's OTel SDK Configuration.
     config:
       file_format: "0.3"
       resource:
@@ -110,12 +168,14 @@ beekeeper:
                   - name: "x-honeycomb-team"
                     value: ${HONEYCOMB_API_KEY}
 
-
+# Configuration options for the Primary Collector.
 primaryCollector:
-  serviceName: "primary-collector"
   serviceAccount:
     create: true
+    # Name of the service account to use if not creating a new one.
     name: ""
+
+  serviceName: "primary-collector"
   service:
     enabled: true
     ports:
@@ -128,12 +188,23 @@ primaryCollector:
         port: 4318
         targetPort: 4318
         protocol: TCP
+
+  # Resource limits & requests.
+  # It is HIGHLY recommended to set resource limits.
+  # resources:
+  #   limits:
+  #     cpu: 250m
+  #     memory: 512Mi
   resources: {}
+
+  # Number of replicas to deploy
   replicaCount: 2
+
   image:
     repository: "honeycombio/supervised-collector"
     pullPolicy: IfNotPresent
     tag: "latest"
+
   defaultEnv:
     HONEYCOMB_API_KEY:
       enabled: true
@@ -143,13 +214,20 @@ primaryCollector:
             name: honeycomb-observability-pipeline
             key: api-key
   extraEnvs: []
+
   volumes: []
   volumeMounts: []
+
+  # configuration options for the OpAMP Supervisor.
   opampsupervisor:
     telemetry:
+      # Enablesthe OpAMP Supervisor's internal telemetry.
       enabled: true
+      # Default endpoint for telemetry data.
+      # When unset (the default), the endpoint will be set to https://api.honeycomb.io.
       defaultEndpoint: ""
       defaultServiceName: opamp-supervisor
+      # The OpAMP Supervisor's configuration file.
       config:
         resource:
           'service.name': '{{ .Values.primaryCollector.opampsupervisor.telemetry.defaultServiceName }}'
@@ -164,3 +242,4 @@ primaryCollector:
                     headers:
                     - name: "x-honeycomb-team"
                       value: ${HONEYCOMB_API_KEY}
+  

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -25,7 +25,7 @@ global:
   #        APIHost: https://api.eu1.honeycomb.io
   #      OTelTracing:
   #        APIHost: https://api.eu1.honeycomb.io
-  #  beekeeker:
+  #  beekeeper:
   #    endpoint: https://api.eu1.honeycomb.io
   #    defaultEnv:
   #      TELEMETRY_ENDPOINT:
@@ -70,7 +70,7 @@ beekeeper:
     pullPolicy: IfNotPresent
     tag: "latest"
 
-  # The Hnoeycomb API endpoint Beekeeper should use.
+  # The Honeycomb API endpoint Beekeeper should use.
   # When unset (the default), Beekeeper will use https://api.honeycomb.io
   endpoint: ""
 
@@ -221,7 +221,7 @@ primaryCollector:
   # configuration options for the OpAMP Supervisor.
   opampsupervisor:
     telemetry:
-      # Enablesthe OpAMP Supervisor's internal telemetry.
+      # Enables the OpAMP Supervisor's internal telemetry.
       enabled: true
       # Default endpoint for telemetry data.
       # When unset (the default), the endpoint will be set to https://api.honeycomb.io.


### PR DESCRIPTION
## Which problem is this PR solving?

Related to https://github.com/honeycombio/pipeline-team/issues/239

## Short description of the changes

Add a json schema to help enforce keys in the values.yaml. This ensures users don't mistype something and get confused. It will also help with changing values in later versions if needed.

## How to verify that this has the expected result

Tested locally with `helm template`.
