### PR TITLE
feat(observability-pipeline): switch collector telemetry config to file

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.42-alpha
+version: 0.0.43-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.43-alpha
+version: 0.0.44-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -66,18 +66,6 @@ spec:
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content | nindent 14 }}  
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
-            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_ENDPOINT.enabled }}
-            - name: TELEMETRY_ENDPOINT
-              {{- include "honeycomb-observability-pipeline.beekeeper.telemetryEndpoint" . | indent 14 }}  
-            {{- end }}
-            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_KEY.enabled }}
-            - name: TELEMETRY_KEY
-              {{- toYaml .Values.beekeeper.defaultEnv.TELEMETRY_KEY.content | nindent 14 }}  
-            {{- end }}
-            {{- if .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.enabled }}
-            - name: TELEMETRY_METRICS_DATASET
-              {{- tpl (toYaml .Values.beekeeper.defaultEnv.TELEMETRY_METRICS_DATASET.content) . | nindent 14 }}  
-            {{- end }}
             {{- if .Values.beekeeper.defaultEnv.LOG_LEVEL.enabled }}
             - name: LOG_LEVEL
               {{- toYaml .Values.beekeeper.defaultEnv.LOG_LEVEL.content | nindent 14 }}  

--- a/charts/observability-pipeline/templates/primary-collector-agent-configmap.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-agent-configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.primaryCollector.agent.telemetry.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "honeycomb-observability-pipeline.fullname" . }}-primary-collector-agent
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "honeycomb-observability-pipeline.primaryCollector.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+data:
+  config: |
+  {{- include "honeycomb-observability-pipeline.primaryCollector.agent.config" . | nindent 4 -}}
+{{- end }}

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -17,6 +17,9 @@ spec:
     metadata:
       annotations:
         {{- include "honeycomb-observability-pipeline.primaryCollector.configTemplateChecksumAnnotation" . | nindent 8 }}
+        {{- if .Values.primaryCollector.agent.telemetry.enabled }}
+        {{- include "honeycomb-observability-pipeline.primaryCollector.agent.configTemplateChecksumAnnotation" . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "honeycomb-observability-pipeline.primaryCollector.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: collector
@@ -66,6 +69,10 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor
+            {{- if .Values.primaryCollector.agent.telemetry.enabled }}
+            - name: agent-config
+              mountPath: /etc/agent
+            {{- end }}
           {{- with .Values.beekeeper.volumeMounts }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -76,6 +83,14 @@ spec:
             items:
               - key: config
                 path: config.yaml
+        {{- if .Values.primaryCollector.agent.telemetry.enabled }}
+        - name: agent-config
+          configMap:
+            name: {{ include "honeycomb-observability-pipeline.fullname" . }}-primary-collector-agent
+            items:
+              - key: config
+                path: config.yaml
+        {{- end }}
       {{- with .Values.primaryCollector.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -88,16 +88,6 @@ beekeeper:
           secretKeyRef:
             name: honeycomb-observability-pipeline
             key: api-key
-    TELEMETRY_ENDPOINT:
-      enabled: true
-    TELEMETRY_KEY:
-      enabled: true
-      content:
-        value: "${env:HONEYCOMB_API_KEY}"
-    TELEMETRY_METRICS_DATASET:
-      enabled: true
-      content:
-        value: "{{ .Values.primaryCollector.serviceName }}-metrics"
     LOG_LEVEL:
       enabled: true
       content:
@@ -153,7 +143,7 @@ beekeeper:
               exporter:
                 otlp:
                   protocol: http/protobuf
-                  endpoint: ${TELEMETRY_ENDPOINT}
+                  endpoint: '{{ include "honeycomb-observability-pipeline.beekeeper.telemetryEndpoint" . }}'
                   headers:
                   - name: "x-honeycomb-team"
                     value: ${HONEYCOMB_API_KEY}
@@ -163,7 +153,7 @@ beekeeper:
               exporter:
                 otlp:
                   protocol: http/protobuf
-                  endpoint: ${TELEMETRY_ENDPOINT}
+                  endpoint: '{{ include "honeycomb-observability-pipeline.beekeeper.telemetryEndpoint" . }}'
                   headers:
                   - name: "x-honeycomb-team"
                     value: ${HONEYCOMB_API_KEY}
@@ -218,6 +208,34 @@ primaryCollector:
   volumes: []
   volumeMounts: []
 
+  # configuration options for the agent (a collector) the OpAMP Supervisor manages
+  agent:
+    telemetry:
+      enabled: true
+      defaultEndpoint: ""
+      file: /etc/agent/config.yaml
+      config:
+        metrics:
+          readers:
+            - periodic:
+                exporter:
+                  otlp:
+                    endpoint: '{{ include "honeycomb-observability-pipeline.primaryCollector.agent.telemetry.defaultEndpoint" . }}'
+                    headers:
+                      x-honeycomb-dataset: primary-collector-metrics
+                      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+                    protocol: http/protobuf
+        logs:
+          encoding: json
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    endpoint: '{{ include "honeycomb-observability-pipeline.primaryCollector.agent.telemetry.defaultEndpoint" . }}'
+                    headers:
+                      x-honeycomb-team: ${env:HONEYCOMB_API_KEY}
+                    protocol: http/protobuf
+                    
   # configuration options for the OpAMP Supervisor.
   opampsupervisor:
     telemetry:


### PR DESCRIPTION
## Which problem is this PR solving?

closes https://github.com/honeycombio/pipeline-team/issues/255

## Short description of the changes

Switch the primary collector's telemetry settings to a local file from helm instead of from Beekeeper. This brings it in line with beekeeper, refinery and the opampsupervisor. It also ensures the collector can emit telemetry even if it doesn't get the chance to talk to beekeeper

## How to verify that this has the expected result

local testing and templating
