### PR TITLE
fix(observability-pipeline): fix bug preventing default install

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.40-alpha
+version: 0.0.41-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -10,10 +10,6 @@
   {{- fail "beekeeper.image.tag must be set" }}
 {{- end }}
 
-{{- if and (not .Values.global.region) (not .Values.beekeeper.endpoint) }}
-  {{- fail "global.region or beekeeper.endpoint must be set" }}
-{{- end }}
-
 {{- if (not .Values.pipelineInstallationID) }}
   {{- fail "pipelineInstallationID must be set" }}
 {{- end }}


### PR DESCRIPTION
## Which problem is this PR solving?

Right now you can install the chart pointing to production-us unless you explicitly set it in beekeeper.endpoint. That was an unintentional side effect of https://github.com/honeycombio/helm-charts/pull/462. Turns out the check I added isn't necessary bc an unset value means `production-us` and I had forgotten to update NOTES.txt

- Closes https://github.com/honeycombio/helm-charts/pull/462

## Short description of the changes

- remove unneeded check.

## How to verify that this has the expected result

helm template
