### PR TITLE
maint: remove unused port

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.42-alpha
+version: 0.0.43-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -109,9 +109,6 @@ spec:
           {{- end }}
           {{- end }}
           ports:
-            - name: config
-              containerPort: 4321
-              protocol: TCP
             - name: opamp
               containerPort: 4320
               protocol: TCP

--- a/charts/observability-pipeline/templates/beekeeper-service.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-service.yaml
@@ -9,10 +9,6 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 4321
-      targetPort: "config"
-      protocol: TCP
-      name: config
     - port: 4320
       targetPort: "opamp"
       protocol: TCP


### PR DESCRIPTION
## Which problem is this PR solving?

The port 4321 is no longer used for beekeeper. Removing it from the definition.
