### PR TITLE
maint(refinery): update chart to use 2.9.5

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.16.2
-appVersion: 2.9.4
+version: 2.16.3
+appVersion: 2.9.5
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

update the chart to use the latest Refinery release 2.9.5
