### PR TITLE
fix(observability-pipeline): allow beekeeper telemetry endpoint to set to non-prod

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.45-alpha
+version: 0.0.46-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -199,9 +199,9 @@ Calculate Beekeeper telemetry endpoint based on region
 */}}
 {{- define "honeycomb-observability-pipeline.beekeeper.telemetryEndpoint" -}}
 {{- if eq .Values.global.region "production-eu" }}
-https://api.eu1.honeycomb.io
+{{- default "https://api.eu1.honeycomb.io" .Values.beekeeper.endpoint }}
 {{- else }}
-https://api.honeycomb.io
+{{- default "https://api.honeycomb.io" .Values.beekeeper.endpoint }}
 {{- end }}
 {{- end }}
 

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -122,7 +122,6 @@ beekeeper:
   # Settings for Beekeeper's internal telemetry.
   telemetry:
     enabled: true
-
     # Beekeeper's OTel SDK Configuration.
     config:
       file_format: "0.3"


### PR DESCRIPTION
## Which problem is this PR solving?

Beekeeper telemetry endpoint cannot currently be easily set to a non-prod url.

## Short description of the changes

- update beekeeper to use `.Values.beekeeper.endpoint` for otel sdk endpoint if it is set.

## How to verify that this has the expected result

templating and installing in sippycup
