### PR TITLE
feat(observability-collector): add probe support for primaryCollector

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.46-alpha
+version: 0.0.47-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -35,6 +35,10 @@
   {{- fail "collector.image.tag must be set" }}
 {{- end }}
 
+{{- if not (eq .Values.primaryCollector.livenessProbe.port .Values.primaryCollector.readinessProbe.port) }}
+  {{- fail "primaryCollector.livenessProbe.port and primaryCollector.readinessProbe.port must be the same" }}
+{{- end }}
+
 
 Your Honeycomb Observability Pipeline is ready.
 

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -112,6 +112,8 @@ agent:
     - {{ .Values.primaryCollector.agent.telemetry.file }}
   {{- end }}
   config_apply_timeout: 10s
+  health_check_host: 0.0.0.0
+  health_check_port: {{ .Values.primaryCollector.livenessProbe.httpGet.port }}
   description:
     identifying_attributes:
       service.name: {{ .Values.primaryCollector.agent.telemetry.defaultServiceName }}

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -66,6 +66,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          livenessProbe:
+          {{- with .Values.primaryCollector.livenessProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          readinessProbe:
+          {{- with .Values.primaryCollector.readinessProbe }}
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor

--- a/charts/observability-pipeline/values.schema.json
+++ b/charts/observability-pipeline/values.schema.json
@@ -194,6 +194,12 @@
             "type": "object"
           }
         },
+        "livenessProbe": {
+          "type": "object"
+        },
+        "readinessProbe": {
+          "type": "object"
+        },
         "volumes": {
           "type": "array",
           "items": {

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -203,6 +203,21 @@ primaryCollector:
             key: api-key
   extraEnvs: []
 
+  # liveness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    httpGet:
+      port: 13133
+      path: /
+
+  # readiness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readinessProbe:
+    httpGet:
+      port: 13133
+      path: /
+
+
   volumes: []
   volumeMounts: []
 


### PR DESCRIPTION
## Which problem is this PR solving?

Add support for readiness and liveness probes in the primary collector

- Closes https://github.com/honeycombio/pipeline-team/issues/300

Depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/39863

## Short description of the changes

- update primaryCollector deployment to support liveness and readiness probe configuration
- update health check host to be `0.0.0.0`.
- update NOTES.txt to enforce liveness and readiness ports are the same.

## How to verify that this has the expected result

Tested using local kind cluster
