### PR TITLE
fix(observability-pipeline): add back refinery telemetry key

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.47-alpha
+version: 0.0.48-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -57,7 +57,14 @@ refinery:
     Logger:
       Type: honeycomb
   environment:
+    # Default key for the HPSF Honeycomb Exporter
     - name: HONEYCOMB_EXPORTER_APIKEY
+      valueFrom:
+        secretKeyRef:
+          name: honeycomb-observability-pipeline
+          key: api-key
+    # Env var for exporting refinery internal telemetry
+    - name: REFINERY_HONEYCOMB_API_KEY
       valueFrom:
         secretKeyRef:
           name: honeycomb-observability-pipeline


### PR DESCRIPTION
## Which problem is this PR solving?

I broke refinery telemetry exporting with https://github.com/honeycombio/helm-charts/pull/477

## Short description of the changes

- add back the default env var for exporting refinery telemetry
- add comments

# Testing

Tested by installing this version of the chart in sippycup

