### PR TITLE
feat(observability-pipeline): set env var for refinery service name

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.53-alpha
+version: 0.0.54-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -237,3 +237,14 @@ Get the name of the beekeeper service for refinery
 {{- printf "%s-%s-%s" .Release.Name "observability-pipeline" "beekeeper" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the name of the refinery service for primary-collector
+*/}}
+{{- define "honeycomb-observability-pipeline.refineryName" -}}
+{{- if contains "refinery" .Release.Name }}
+{{- print "refinery" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name "refinery" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -59,6 +59,10 @@ spec:
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
             {{- end }}
+            {{- if .Values.primaryCollector.defaultEnv.STRAWS_REFINERY_SERVICE.enabled }}
+            - name: STRAWS_REFINERY_SERVICE
+              {{- tpl (toYaml .Values.primaryCollector.defaultEnv.STRAWS_REFINERY_SERVICE.content) . | nindent 14 }}  
+            {{- end }}
             {{- with .Values.primaryCollector.extraEnvs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/observability-pipeline/values.schema.json
+++ b/charts/observability-pipeline/values.schema.json
@@ -185,6 +185,9 @@
           "properties": {
             "HONEYCOMB_API_KEY": {
               "type": "object"
+            },
+            "STRAWS_REFINERY_SERVICE": {
+              "type": "object"
             }
           }          
         },

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -214,6 +214,8 @@ primaryCollector:
     STRAWS_REFINERY_SERVICE:
       enabled: true
       content:
+        # If you change the refinery service name via refinery.nameOverride or refinery.fullnameOverride
+        # you'll need to change this value too.
         value: '{{ include "honeycomb-observability-pipeline.refineryName" . }}'
   extraEnvs: []
 

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -211,6 +211,10 @@ primaryCollector:
           secretKeyRef:
             name: honeycomb-observability-pipeline
             key: api-key
+    STRAWS_REFINERY_SERVICE:
+      enabled: true
+      content:
+        value: '{{ include "honeycomb-observability-pipeline.refineryName" . }}'
   extraEnvs: []
 
   volumes: []


### PR DESCRIPTION
## Which problem is this PR solving?

- related to https://github.com/honeycombio/pipeline-team/issues/383

## Short description of the changes

- update chart version
- update json schema with new default env var
- add new default env var to primary collector that provides access to installed refinery service name

## How to verify that this has the expected result

local templating
