### PR TITLE
fix(observability-pipeline): fix beekeeper url for opampsupervisor

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.54-alpha
+version: 0.0.55-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -89,7 +89,7 @@ Build config file for opamp supervisor
 */}}
 {{- define "honeycomb-observability-pipeline.primaryCollector.config" -}}
 server:
-  endpoint: ws://{{ include "honeycomb-observability-pipeline.name" . }}-observability-pipeline-beekeeper:4320/v1/opamp
+  endpoint: ws://{{ include "honeycomb-observability-pipeline.beekeeperName" . }}:4320/v1/opamp
   tls:
     # Disable verification to test locally.
     # Don't do this in production.


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes the same issue from https://github.com/honeycombio/helm-charts/pull/467  that broke the url when the chart name was used in the release name, this time for the primary collector.

- Related to https://github.com/honeycombio/pipeline-team/issues/390

## Short description of the changes

- use the proper beekeeper service name for the opamp server host.

## How to verify that this has the expected result

local templating
