### PR TITLE
feat: Added template rendering tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
             echo "export K8S_VERSION=$K8S_VERSION" >> $BASH_ENV
             .circleci/install_testing_tools.sh
       - run:
+          name: Test chart rendering changes
+          command: make test-render
+      - run:
           name: Start minikube
           command: |
             minikube start --driver=none --kubernetes-version=${K8S_VERSION}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 ### VSCode ###
 .vscode/
 *.code-workspace
+
+tests/*/rendered-compare

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,11 @@ lint:
 .PHONY: test
 test:
 	ct install --config ./ct.yaml --excluded-charts htp --excluded-charts observability-pipeline
+
+.PHONY: render-templates
+render-templates:
+	cd tests && ./render-all-test-templates.sh
+
+.PHONY: test-render
+test-render:
+	cd tests && ./render-all-test-templates.sh -b -d rendered-compare && ./compare-rendered-templates.sh 

--- a/tests/compare-rendered-templates.sh
+++ b/tests/compare-rendered-templates.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+RENDERED_DIR=rendered
+COMPARE_DIR=rendered-compare
+
+while getopts "b:c:" opt; do
+  case $opt in
+    b) RENDERED_DIR=$OPTARG;;
+    d) COMPARE_DIR=$OPTARG;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+chart_dirs=($(ls -d */))
+
+for chart_dir in "${chart_dirs[@]}"; do
+    echo "comparing rendered and rendered_compare for $chart_dir"
+
+    base_dir=${chart_dir}/${RENDERED_DIR}
+    compare_dir=${chart_dir}/${COMPARE_DIR}
+
+    # compare the directories and return an error if they are not the same with a print out of the line differences
+    diff -u ./$base_dir ./$compare_dir
+done
+

--- a/tests/observability-pipeline/base-values.yaml
+++ b/tests/observability-pipeline/base-values.yaml
@@ -1,0 +1,2 @@
+pipelineInstallationID: test-installation-id
+publicMgmtAPIKey: test-management-key-id

--- a/tests/observability-pipeline/rendered/rendered-eu.yaml
+++ b/tests/observability-pipeline/rendered/rendered-eu.yaml
@@ -1,0 +1,662 @@
+---
+# Source: observability-pipeline/charts/refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: observability-pipeline/templates/beekeeper-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+---
+# Source: observability-pipeline/templates/primary-collector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+---
+# Source: observability-pipeline/charts/refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://api.eu1.honeycomb.io
+    LegacyMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    Logger:
+      Type: honeycomb
+    Network:
+      HoneycombAPI: https://api.eu1.honeycomb.io
+    OTelMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+      Enabled: true
+    OTelTracing:
+      APIHost: https://api.eu1.honeycomb.io
+    OpAMP:
+      Enabled: true
+      Endpoint: ws://test-observability-pipeline-beekeeper:4320/v1/opamp
+      RecordUsage: false
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: false
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: observability-pipeline/charts/refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: observability-pipeline/templates/beekeeper-configmap-otel.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+data:
+  otel-config: |
+    file_format: "0.3"
+    logger_provider:
+      processors:
+      - batch:
+          exporter:
+            otlp:
+              endpoint: 'https://api.eu1.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              protocol: http/protobuf
+    meter_provider:
+      readers:
+      - periodic:
+          exporter:
+            otlp:
+              endpoint: 'https://api.eu1.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              - name: x-honeycomb-dataset
+                value: beekeeper-metrics
+              protocol: http/protobuf
+              temporality_preference: delta
+    propagator:
+      composite:
+      - tracecontext
+      - baggage
+    tracer_provider:
+      processors:
+      - batch:
+          exporter:
+            otlp:
+              endpoint: 'https://api.eu1.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              protocol: http/protobuf
+---
+# Source: observability-pipeline/templates/primary-collector-agent-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-primary-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+data:
+  config: |
+    service:
+      telemetry:
+        resource:
+          service.name: primary-collector
+        logs:
+          encoding: json
+          processors:
+          - batch:
+              exporter:
+                otlp:
+                  endpoint: 'https://api.eu1.honeycomb.io'
+                  headers:
+                  - name: x-honeycomb-team
+                    value: ${env:HONEYCOMB_API_KEY}
+                  protocol: http/protobuf
+        metrics:
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: 'https://api.eu1.honeycomb.io'
+                  headers:
+                  - name: x-honeycomb-dataset
+                    value: primary-collector-metrics
+                  - name: x-honeycomb-team
+                    value: ${env:HONEYCOMB_API_KEY}
+                  protocol: http/protobuf
+                  temporality_preference: delta
+---
+# Source: observability-pipeline/templates/primary-collector-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+data:
+  config: |
+    server:
+      endpoint: ws://test-observability-pipeline-beekeeper:4320/v1/opamp
+      tls:
+        # Disable verification to test locally.
+        # Don't do this in production.
+        insecure_skip_verify: true
+        # For more TLS settings see config/configtls.ClientConfig
+    
+    capabilities:
+      reports_effective_config: true
+      reports_own_metrics: true
+      reports_own_logs: true
+      reports_own_traces: true
+      reports_health: true
+      accepts_remote_config: true
+      reports_remote_config: true
+    
+    agent:
+      executable: /otelcol-contrib
+      config_files: 
+        - /etc/agent/config.yaml
+      config_apply_timeout: 10s
+      description:
+        identifying_attributes:
+          service.name: primary-collector
+          service.namespace: htp.collector
+    
+    storage:
+      directory: /var/lib/otelcol/supervisor
+    
+    telemetry:
+      logs:
+        level: info
+        processors:
+        - batch:
+            exporter:
+              otlp:
+                endpoint: 'https://api.eu1.honeycomb.io'
+                headers:
+                - name: x-honeycomb-team
+                  value: ${HONEYCOMB_API_KEY}
+                protocol: http/protobuf
+      resource:
+        service.name: 'opamp-supervisor'
+---
+# Source: observability-pipeline/charts/refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/charts/refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/templates/beekeeper-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4320
+      targetPort: "opamp"
+      protocol: TCP
+      name: opamp
+  selector:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/templates/primary-collector-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+spec:
+  type: ClusterIP
+  ports:
+    - appProtocol: grpc
+      name: otlp
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: 4318
+  selector:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/charts/refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: observability-pipeline/charts/refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          env:
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: REFINERY_HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml
+---
+# Source: observability-pipeline/templates/beekeeper-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-beekeeper
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-beekeeper
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/component: beekeeper
+    spec:
+      serviceAccountName: test-observability-pipeline-beekeeper
+      containers:
+        - name: observability-pipeline
+          image: "honeycombio/beekeeper:v0.0.14-alpha"
+          imagePullPolicy: IfNotPresent
+          args:
+            - -otel-config
+            - /etc/beekeeper/otel-config.yaml
+          env:
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: pipelineInstallationID=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_API
+              value: https://api.eu1.honeycomb.io
+            - name: HONEYCOMB_INSTALLATION_ID
+              value: test-installation-id
+            - name: HONEYCOMB_MGMT_API_KEY
+              value: test-management-key-id
+            - name: HONEYCOMB_MGMT_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: management-api-secret
+                  name: honeycomb-observability-pipeline  
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/beekeeper
+          ports:
+            - name: opamp
+              containerPort: 4320
+              protocol: TCP
+      volumes:
+        - name: otel-config
+          configMap:
+            name: test-observability-pipeline-beekeeper
+            items:
+              - key: otel-config
+                path: otel-config.yaml
+---
+# Source: observability-pipeline/templates/primary-collector-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-primary-collector
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-primary-collector
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/component: collector
+    spec:
+      serviceAccountName: test-observability-pipeline-primary-collector
+      containers:
+        - name: observability-pipeline
+          image: "honeycombio/supervised-collector:v0.0.6"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/opampsupervisor/config.yaml
+          env:
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: STRAWS_COLLECTOR_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: pipelineInstallationID=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: STRAWS_REFINERY_SERVICE
+              value: 'test-refinery'
+          volumeMounts:
+            - name: config
+              mountPath: /etc/opampsupervisor
+            - name: agent-config
+              mountPath: /etc/agent
+      volumes:
+        - name: config
+          configMap:
+            name: test-observability-pipeline-primary-collector
+            items:
+              - key: config
+                path: config.yaml
+        - name: agent-config
+          configMap:
+            name: test-observability-pipeline-primary-collector-agent
+            items:
+              - key: config
+                path: config.yaml

--- a/tests/observability-pipeline/rendered/rendered-unset-region.yaml
+++ b/tests/observability-pipeline/rendered/rendered-unset-region.yaml
@@ -1,0 +1,653 @@
+---
+# Source: observability-pipeline/charts/refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: observability-pipeline/templates/beekeeper-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+---
+# Source: observability-pipeline/templates/primary-collector-serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+---
+# Source: observability-pipeline/charts/refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    Logger:
+      Type: honeycomb
+    OTelMetrics:
+      Enabled: true
+    OpAMP:
+      Enabled: true
+      Endpoint: ws://test-observability-pipeline-beekeeper:4320/v1/opamp
+      RecordUsage: false
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: false
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: observability-pipeline/charts/refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: observability-pipeline/templates/beekeeper-configmap-otel.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+data:
+  otel-config: |
+    file_format: "0.3"
+    logger_provider:
+      processors:
+      - batch:
+          exporter:
+            otlp:
+              endpoint: 'https://api.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              protocol: http/protobuf
+    meter_provider:
+      readers:
+      - periodic:
+          exporter:
+            otlp:
+              endpoint: 'https://api.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              - name: x-honeycomb-dataset
+                value: beekeeper-metrics
+              protocol: http/protobuf
+              temporality_preference: delta
+    propagator:
+      composite:
+      - tracecontext
+      - baggage
+    tracer_provider:
+      processors:
+      - batch:
+          exporter:
+            otlp:
+              endpoint: 'https://api.honeycomb.io'
+              headers:
+              - name: x-honeycomb-team
+                value: ${HONEYCOMB_API_KEY}
+              protocol: http/protobuf
+---
+# Source: observability-pipeline/templates/primary-collector-agent-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-primary-collector-agent
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+data:
+  config: |
+    service:
+      telemetry:
+        resource:
+          service.name: primary-collector
+        logs:
+          encoding: json
+          processors:
+          - batch:
+              exporter:
+                otlp:
+                  endpoint: 'https://api.honeycomb.io'
+                  headers:
+                  - name: x-honeycomb-team
+                    value: ${env:HONEYCOMB_API_KEY}
+                  protocol: http/protobuf
+        metrics:
+          readers:
+          - periodic:
+              exporter:
+                otlp:
+                  endpoint: 'https://api.honeycomb.io'
+                  headers:
+                  - name: x-honeycomb-dataset
+                    value: primary-collector-metrics
+                  - name: x-honeycomb-team
+                    value: ${env:HONEYCOMB_API_KEY}
+                  protocol: http/protobuf
+                  temporality_preference: delta
+---
+# Source: observability-pipeline/templates/primary-collector-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+data:
+  config: |
+    server:
+      endpoint: ws://test-observability-pipeline-beekeeper:4320/v1/opamp
+      tls:
+        # Disable verification to test locally.
+        # Don't do this in production.
+        insecure_skip_verify: true
+        # For more TLS settings see config/configtls.ClientConfig
+    
+    capabilities:
+      reports_effective_config: true
+      reports_own_metrics: true
+      reports_own_logs: true
+      reports_own_traces: true
+      reports_health: true
+      accepts_remote_config: true
+      reports_remote_config: true
+    
+    agent:
+      executable: /otelcol-contrib
+      config_files: 
+        - /etc/agent/config.yaml
+      config_apply_timeout: 10s
+      description:
+        identifying_attributes:
+          service.name: primary-collector
+          service.namespace: htp.collector
+    
+    storage:
+      directory: /var/lib/otelcol/supervisor
+    
+    telemetry:
+      logs:
+        level: info
+        processors:
+        - batch:
+            exporter:
+              otlp:
+                endpoint: 'https://api.honeycomb.io'
+                headers:
+                - name: x-honeycomb-team
+                  value: ${HONEYCOMB_API_KEY}
+                protocol: http/protobuf
+      resource:
+        service.name: 'opamp-supervisor'
+---
+# Source: observability-pipeline/charts/refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/charts/refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/templates/beekeeper-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4320
+      targetPort: "opamp"
+      protocol: TCP
+      name: opamp
+  selector:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/templates/primary-collector-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+spec:
+  type: ClusterIP
+  ports:
+    - appProtocol: grpc
+      name: otlp
+      port: 4317
+      protocol: TCP
+      targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: 4318
+  selector:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+---
+# Source: observability-pipeline/charts/refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: observability-pipeline/charts/refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          env:
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: REFINERY_HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml
+---
+# Source: observability-pipeline/templates/beekeeper-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-observability-pipeline-beekeeper
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-beekeeper
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: beekeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-beekeeper
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-beekeeper
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/component: beekeeper
+    spec:
+      serviceAccountName: test-observability-pipeline-beekeeper
+      containers:
+        - name: observability-pipeline
+          image: "honeycombio/beekeeper:v0.0.14-alpha"
+          imagePullPolicy: IfNotPresent
+          args:
+            - -otel-config
+            - /etc/beekeeper/otel-config.yaml
+          env:
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: pipelineInstallationID=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_API
+              value: https://api.honeycomb.io
+            - name: HONEYCOMB_INSTALLATION_ID
+              value: test-installation-id
+            - name: HONEYCOMB_MGMT_API_KEY
+              value: test-management-key-id
+            - name: HONEYCOMB_MGMT_API_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: management-api-secret
+                  name: honeycomb-observability-pipeline  
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: otel-config
+              mountPath: /etc/beekeeper
+          ports:
+            - name: opamp
+              containerPort: 4320
+              protocol: TCP
+      volumes:
+        - name: otel-config
+          configMap:
+            name: test-observability-pipeline-beekeeper
+            items:
+              - key: otel-config
+                path: otel-config.yaml
+---
+# Source: observability-pipeline/templates/primary-collector-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-observability-pipeline-primary-collector
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-primary-collector
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: collector
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-primary-collector
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-primary-collector
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/component: collector
+    spec:
+      serviceAccountName: test-observability-pipeline-primary-collector
+      containers:
+        - name: observability-pipeline
+          image: "honeycombio/supervised-collector:v0.0.6"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/opampsupervisor/config.yaml
+          env:
+            - name: K8S_NAMESPACE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: K8S_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+            - name: STRAWS_COLLECTOR_POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: pipelineInstallationID=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: honeycomb-observability-pipeline
+            - name: STRAWS_REFINERY_SERVICE
+              value: 'test-refinery'
+          volumeMounts:
+            - name: config
+              mountPath: /etc/opampsupervisor
+            - name: agent-config
+              mountPath: /etc/agent
+      volumes:
+        - name: config
+          configMap:
+            name: test-observability-pipeline-primary-collector
+            items:
+              - key: config
+                path: config.yaml
+        - name: agent-config
+          configMap:
+            name: test-observability-pipeline-primary-collector-agent
+            items:
+              - key: config
+                path: config.yaml

--- a/tests/observability-pipeline/tests/eu.yaml
+++ b/tests/observability-pipeline/tests/eu.yaml
@@ -1,0 +1,2 @@
+global:
+  region: production-eu

--- a/tests/observability-pipeline/tests/unset-region.yaml
+++ b/tests/observability-pipeline/tests/unset-region.yaml
@@ -1,0 +1,2 @@
+global:
+  region: ""

--- a/tests/render-all-test-templates.sh
+++ b/tests/render-all-test-templates.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+BUILD_DEPENDENCIES=false
+RENDERED_DIR=rendered
+
+while getopts "bd:" opt; do
+  case $opt in
+    b) BUILD_DEPENDENCIES=true;;
+    d) RENDERED_DIR=$OPTARG;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+chart_dirs=($(ls -d */))
+
+for chart_dir in "${chart_dirs[@]}"; do
+
+    if [ $BUILD_DEPENDENCIES = true ]; then
+        echo "Building dependencies"
+        for chart_dir in */; do
+            helm repo add honeycomb https://honeycombio.github.io/helm-charts
+            helm dependency build ../charts/${chart_dir}
+        done
+    fi
+
+    rendered_dir=./${chart_dir}/${RENDERED_DIR}
+
+    # create the rendered directory if it doesn't exist
+    mkdir -p ${rendered_dir}
+    rm -f ${rendered_dir}/*
+
+    echo "Rendering all templates for ${chart_dir}"
+
+    for values_file in ./${chart_dir}/tests/*.yaml; do
+        filename=$(basename "$values_file" .yaml)
+        # skip the values file
+        if [ "$filename" = "values" ]; then
+            continue
+        fi
+
+        echo "Rendering $filename"
+        helm template test ../charts/${chart_dir}/ \
+            --values ${chart_dir}/base-values.yaml \
+            --values "$values_file" \
+            | sed '/helm.sh\/chart\:/d' | sed '/helm.sh\/hook/d' | sed '/managed-by\: Helm/d' | sed '/checksum\//d' \
+            > "${rendered_dir}/rendered-${filename}.yaml"
+    done
+
+done


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

When committing changes that will change the rendered output, it's hard to know if there are adverse effects to that.

## Short description of the changes

This PR adds 2 testing scripts.

`render-all-test-templates.sh` which will render all the charts based on values files located in the tests folder. This also strips the details that always change like the chart version to make it clearer.
`compare-test-rendered.sh` which will compare 2 sets of rendered files.

I've also added this to CI, so that if someone has not committed the updated rendered files CI will fail. This will ensure that PR reviews show all the expected changes a customer will see.

## How to verify that this has the expected result

The build should pass, this PR makes no changes to the charts.