### PR TITLE
fix(observability-pipeline): update pipeline installation telemetry field

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.56-alpha
+version: 0.0.57-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -55,7 +55,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipeline_installation.id={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
               value: {{ include "honeycomb-observability-pipeline.beekeeper.endpoint" . }}
             - name: HONEYCOMB_INSTALLATION_ID

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipeline_installation.id={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             {{- if .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -54,6 +54,24 @@ refinery:
     Logger:
       Type: honeycomb
   environment:
+    - name: K8S_NAMESPACE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: K8S_POD_UID
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.uid
+    - name: OTEL_RESOURCE_ATTRIBUTES
+      value: pipeline_installation.id={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
     # Default key for the HPSF Honeycomb Exporter
     - name: HONEYCOMB_EXPORTER_APIKEY
       valueFrom:


### PR DESCRIPTION
## Which problem is this PR solving?

Updates telemetry field that was using a bad name

- Related to https://github.com/honeycombio/pipeline-team/issues/411

## Short description of the changes

- update field to be `pipeline_installation.id`
- add field, and other missing fields, to Refinery

## How to verify that this has the expected result

sippycup
