### PR TITLE
feat(refinery): allowing us1 and eu1 as regions for refinery, including from `global`

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.16.3
+version: 2.16.4
 appVersion: 2.9.5
 keywords:
   - refinery

--- a/charts/refinery/templates/_helpers.tpl
+++ b/charts/refinery/templates/_helpers.tpl
@@ -112,11 +112,12 @@ Build config file for Refinery
 {{-     end }}
 {{-   end }}
 {{- end }}
-{{- if eq (include "refinery.region" .) "production-eu" }}
+{{- if or (eq (include "refinery.region" .) "production-eu") (eq (include "refinery.region" .) "eu1") }}
 {{- $config = mustMergeOverwrite (include "refinery.productionEUConfig" .Values | fromYaml) $config }}
 {{- end }}
-{{- if eq .Values.region "custom" }}
-{{- $config = mustMergeOverwrite (include "refinery.customConfig" .Values | fromYaml) $config }}
+{{- if eq (include "refinery.region" .) "custom" }}
+{{- $customEndpoint := (default .Values.customEndpoint (.Values.global).customEndpoint) | trimSuffix "/" }}
+{{- $config = mustMergeOverwrite (include "refinery.customConfig" $customEndpoint | fromYaml) $config }}
 {{- end }}
 {{- tpl (toYaml $config) . }}
 {{- end }}
@@ -126,7 +127,7 @@ Build config file for Refinery
 {{- end}}
 
 {{- define "refinery.region" -}}
-{{- default "" (default (.Values.global).region .Values.region) }}
+{{- default "us1" (default (.Values.global).region .Values.region) }}
 {{- end }}
 
 {{- define "refinery.productionEUConfig" -}}
@@ -144,15 +145,15 @@ OTelTracing:
 
 {{- define "refinery.customConfig" -}}
 Network:
-  HoneycombAPI: {{ .Values.customEndpoint }}
+  HoneycombAPI: {{ . }}
 HoneycombLogger:
-  APIHost: {{ .Values.customEndpoint }}
+  APIHost: {{ . }}
 LegacyMetrics:
-  APIHost: {{ .Values.customEndpoint }}
+  APIHost: {{ . }}
 OTelMetrics:
-  APIHost: {{ .Values.customEndpoint }}
+  APIHost: {{ . }}
 OTelTracing:
-  APIHost: {{ .Values.customEndpoint }}
+  APIHost: {{ . }}
 {{- end }}
 
 {{/*

--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -3,6 +3,13 @@
   "type": "object",
   "title": "Values",
   "properties": {
+    "region": {
+        "type": "string",
+        "enum": ["us1", "eu1", "custom","production-eu", ""]
+    },
+    "customEndpoint": {
+        "type": "string"
+    },
     "config": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -1,25 +1,16 @@
 # Default values for refinery.
 
-# This setting configures the default endpoints. All configuration endpoints can still be set and will take precedence.
-# The default value is ''. When unset, Refinery's default values will be used for any unconfigured endpoints.
+# This setting configures the default endpoints. All endpoints can still be configured and will take precedence.
+# The default value is '' (unset), which will apply the values for 'us1'.
 # Other valid values are:
-#  - production-eu
+#  - eu1
 #  - custom
 #
-# When `production-eu` is set, the refinery config is updated to include:
-#   Network:
-#     HoneycombAPI: https://api.eu1.honeycomb.io
-#   HoneycombLogger:
-#     APIHost: https://api.eu1.honeycomb.io
-#   LegacyMetrics:
-#     APIHost: https://api.eu1.honeycomb.io
-#   OTelMetrics:
-#     APIHost: https://api.eu1.honeycomb.io
-#   OTelTracing:
-#     APIHost: https://api.eu1.honeycomb.io
+# When 'us1' is selected, the endpoints for all services are set to https://api.honeycomb.io.
+# When 'eu1' is selected, the endpoints for all services are set to https://api.eu1.honeycomb.io.
 #
 # Any values you've configured will take precedence.
-# Reminder that LegacyMetrics, OTelMetrics, and OTelTracing still need to be enabled to be used.
+# NOTE: If you're using this as a subchart, use `global.region` instead, and leave this unset.
 region: ""
 # When region=custom this field's value will be used to set Refinery's various endpoints
 customEndpoint: ""

--- a/tests/refinery/rendered/rendered-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-customEndpoint.yaml
@@ -1,0 +1,257 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://this.is.a.test
+    LegacyMetrics:
+      APIHost: https://this.is.a.test
+    Network:
+      HoneycombAPI: https://this.is.a.test
+    OTelMetrics:
+      APIHost: https://this.is.a.test
+    OTelTracing:
+      APIHost: https://this.is.a.test
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-eu.yaml
+++ b/tests/refinery/rendered/rendered-eu.yaml
@@ -1,0 +1,257 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://api.eu1.honeycomb.io
+    LegacyMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    Network:
+      HoneycombAPI: https://api.eu1.honeycomb.io
+    OTelMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    OTelTracing:
+      APIHost: https://api.eu1.honeycomb.io
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-eu1.yaml
+++ b/tests/refinery/rendered/rendered-eu1.yaml
@@ -1,0 +1,257 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://api.eu1.honeycomb.io
+    LegacyMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    Network:
+      HoneycombAPI: https://api.eu1.honeycomb.io
+    OTelMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    OTelTracing:
+      APIHost: https://api.eu1.honeycomb.io
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-global-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-global-customEndpoint.yaml
@@ -1,0 +1,257 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://this.is.a.test
+    LegacyMetrics:
+      APIHost: https://this.is.a.test
+    Network:
+      HoneycombAPI: https://this.is.a.test
+    OTelMetrics:
+      APIHost: https://this.is.a.test
+    OTelTracing:
+      APIHost: https://this.is.a.test
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-global-region-eu1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-eu1.yaml
@@ -1,0 +1,257 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://api.eu1.honeycomb.io
+    LegacyMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    Network:
+      HoneycombAPI: https://api.eu1.honeycomb.io
+    OTelMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    OTelTracing:
+      APIHost: https://api.eu1.honeycomb.io
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-global-region-us1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-us1.yaml
@@ -1,0 +1,247 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-unset-region.yaml
+++ b/tests/refinery/rendered/rendered-unset-region.yaml
@@ -1,0 +1,247 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/rendered/rendered-us1.yaml
+++ b/tests/refinery/rendered/rendered-us1.yaml
@@ -1,0 +1,247 @@
+---
+# Source: refinery/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+---
+# Source: refinery/templates/configmap-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-config
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    Debugging:
+      AdditionalErrorFields:
+      - trace.span_id
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    PrometheusMetrics:
+      Enabled: true
+      ListenAddr: 0.0.0.0:9090
+    RedisPeerManagement:
+      Host: 'test-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
+---
+# Source: refinery/templates/configmap-rules.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-refinery-rules
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
+---
+# Source: refinery/templates/service-redis.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+    - port: 9090
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+
+  selector:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+---
+# Source: refinery/templates/deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: refinery-redis
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: refinery/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "2.9.5"
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: refinery
+      app.kubernetes.io/instance: test
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        prometheus.io/port: "9090"
+        prometheus.io/scrape: "true"
+      labels:
+        app.kubernetes.io/name: refinery
+        app.kubernetes.io/instance: test
+    spec:
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: test-refinery
+      securityContext:
+        {}
+      containers:
+        - name: refinery
+          securityContext:
+            {}
+          image: "honeycombio/refinery:2.9.5"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/refinery/tests/customEndpoint.yaml
+++ b/tests/refinery/tests/customEndpoint.yaml
@@ -1,0 +1,2 @@
+  region: custom
+  customEndpoint: https://this.is.a.test

--- a/tests/refinery/tests/eu.yaml
+++ b/tests/refinery/tests/eu.yaml
@@ -1,0 +1,1 @@
+region: "production-eu"

--- a/tests/refinery/tests/eu1.yaml
+++ b/tests/refinery/tests/eu1.yaml
@@ -1,0 +1,1 @@
+region: "eu1"

--- a/tests/refinery/tests/global-customEndpoint.yaml
+++ b/tests/refinery/tests/global-customEndpoint.yaml
@@ -1,0 +1,3 @@
+global:
+  region: custom
+  customEndpoint: https://this.is.a.test

--- a/tests/refinery/tests/global-region-eu1.yaml
+++ b/tests/refinery/tests/global-region-eu1.yaml
@@ -1,0 +1,2 @@
+global:
+  region: "eu1"

--- a/tests/refinery/tests/global-region-us1.yaml
+++ b/tests/refinery/tests/global-region-us1.yaml
@@ -1,0 +1,2 @@
+global:
+  region: "us1"

--- a/tests/refinery/tests/unset-region.yaml
+++ b/tests/refinery/tests/unset-region.yaml
@@ -1,0 +1,2 @@
+region: ""
+customEndpoint: ""

--- a/tests/refinery/tests/us1.yaml
+++ b/tests/refinery/tests/us1.yaml
@@ -1,0 +1,1 @@
+region: "us1"


### PR DESCRIPTION
## Which problem is this PR solving?

The charts should remain consistent with naming of environment in honeycomb, in that it should allow eu1, us1, etc. without `production-`

- Related to https://github.com/honeycombio/pipeline-team/issues/398

## Short description of the changes

updated the schema and _helper to take into account new regions

## How to verify that this has the expected result

The tests cover all the rendering issues