### PR TITLE
feat(refinery): allow templating env vars

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.16.5
+version: 2.17.0
 appVersion: 2.9.5
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment.yaml
+++ b/charts/refinery/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
             {{- end }}
           {{- with .Values.environment }}
           env:
-          {{- toYaml . | nindent 12 }}
+            {{- tpl (. | toYaml) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.lifecycle }}
           lifecycle:

--- a/charts/refinery/values.yaml
+++ b/charts/refinery/values.yaml
@@ -158,7 +158,10 @@ fullnameOverride: ""
 # - Redis Host: REFINERY_REDIS_HOST
 # - Redis Username: REFINERY_REDIS_USERNAME
 # - Redis Password: REFINERY_REDIS_PASSWORD
-environment: []
+#
+# Supports templating. To escape existing instances of {{ }}, use {{` <original content> `}}.
+# For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
+environment:
   # - name: REFINERY_HONEYCOMB_API_KEY
   #   valueFrom:
   #     secretKeyRef:


### PR DESCRIPTION
## Which problem is this PR solving?

Allow templating environment variables

- Related to https://github.com/honeycombio/pipeline-team/issues/411

## Short description of the changes

- update chart to run `.Values.environment` through `tpl`. This enables users to set environment variables using helm templates. We'll use this in the observability-pipeline chart to set otel resource attributes using values from the values.yaml.

## How to verify that this has the expected result

local templating.
