### PR TITLE
fix(tests): Fixed the test script as it wasn't re-rendering all chart templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,7 @@ render-templates:
 .PHONY: test-render
 test-render:
 	cd tests && ./render-all-test-templates.sh -b -d rendered-compare && ./compare-rendered-templates.sh 
+
+.PHONY: render-base-templates
+render-base-templates:
+	cd tests && ./render-all-test-templates.sh -b -d rendered

--- a/tests/compare-rendered-templates.sh
+++ b/tests/compare-rendered-templates.sh
@@ -16,13 +16,19 @@ done
 
 chart_dirs=($(ls -d */))
 
+has_errors=0
+
 for chart_dir in "${chart_dirs[@]}"; do
     echo "comparing rendered and rendered_compare for $chart_dir"
 
-    base_dir=${chart_dir}/${RENDERED_DIR}
-    compare_dir=${chart_dir}/${COMPARE_DIR}
+    base_dir=${chart_dir}${RENDERED_DIR}
+    compare_dir=${chart_dir}${COMPARE_DIR}
 
     # compare the directories and return an error if they are not the same with a print out of the line differences
-    diff -u ./$base_dir ./$compare_dir
+    result=$(diff -u ./$base_dir ./$compare_dir)
+    if [ -n "$result" ]; then
+        has_errors=1
+    fi
 done
 
+exit $is_error

--- a/tests/render-all-test-templates.sh
+++ b/tests/render-all-test-templates.sh
@@ -21,14 +21,12 @@ chart_dirs=($(ls -d */))
 for chart_dir in "${chart_dirs[@]}"; do
 
     if [ $BUILD_DEPENDENCIES = true ]; then
-        echo "Building dependencies"
-        for chart_dir in */; do
-            helm repo add honeycomb https://honeycombio.github.io/helm-charts
-            helm dependency build ../charts/${chart_dir}
-        done
+        echo "Building dependencies for ${chart_dir}"
+        helm repo add honeycomb https://honeycombio.github.io/helm-charts
+        helm dependency build ../charts/${chart_dir}
     fi
 
-    rendered_dir=./${chart_dir}/${RENDERED_DIR}
+    rendered_dir=./${chart_dir}${RENDERED_DIR}
 
     # create the rendered directory if it doesn't exist
     mkdir -p ${rendered_dir}


### PR DESCRIPTION
## Which problem is this PR solving?

Rendering tests had a bug, and were therefore only testing refinery. This meant that the test-render hadn't picked up a change in the `securityContext` for redis which is now included in this PR.

## Short description of the changes

fixed the `test-render` action, and added an easy make command for re-rendering the files.

## How to verify that this has the expected result

Build pipeline doesn't fail