### PR TITLE
feat(observability-pipeline): renamed the pipelineInstallationId variable

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.57-alpha
+version: 0.0.58-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/README.md
+++ b/charts/observability-pipeline/README.md
@@ -30,7 +30,7 @@ To install the chart with the release name `my-pipeline`, run the following comm
 
 ```shell
 helm install my-pipeline honeycomb/observability-pipeline \
-    --set pipelineInstallationID="pipeline-intallation-id" \
+    --set global.pipeline.id="pipeline-intallation-id" \
     --set publicMgmtAPIKey="public-management-key-id"
 ```
 

--- a/charts/observability-pipeline/templates/NOTES.txt
+++ b/charts/observability-pipeline/templates/NOTES.txt
@@ -10,8 +10,8 @@
   {{- fail "beekeeper.image.tag must be set" }}
 {{- end }}
 
-{{- if (not .Values.pipelineInstallationID) }}
-  {{- fail "pipelineInstallationID must be set" }}
+{{- if (not .Values.global.pipeline.id) }}
+  {{- fail ".global.pipeline.id must be set" }}
 {{- end }}
 
 {{- if (not .Values.publicMgmtAPIKey) }}

--- a/charts/observability-pipeline/templates/beekeeper-deployment.yaml
+++ b/charts/observability-pipeline/templates/beekeeper-deployment.yaml
@@ -55,11 +55,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipelineInstallationID={{ .Values.global.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
               value: {{ include "honeycomb-observability-pipeline.beekeeper.endpoint" . }}
             - name: HONEYCOMB_INSTALLATION_ID
-              value: {{ .Values.pipelineInstallationID }}
+              value: {{ .Values.global.pipeline.id }}
             - name: HONEYCOMB_MGMT_API_KEY
               value: {{ .Values.publicMgmtAPIKey }}
             - name: HONEYCOMB_MGMT_API_SECRET

--- a/charts/observability-pipeline/templates/primary-collector-deployment.yaml
+++ b/charts/observability-pipeline/templates/primary-collector-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipelineInstallationID={{ .Values.pipelineInstallationID }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipelineInstallationID={{ .Values.global.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             {{- if .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  

--- a/charts/observability-pipeline/values.schema.json
+++ b/charts/observability-pipeline/values.schema.json
@@ -10,6 +10,15 @@
     "global": {
       "type": "object",
       "properties": {
+        "pipeline": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          }
+        },
         "region": {
           "type": "string",
           "enum": ["us1", "eu1", "custom"]
@@ -18,9 +27,6 @@
             "type": "string"
         }
       }
-    },
-    "pipelineInstallationID": {
-      "type": "string"
     },
     "publicMgmtAPIKey": {
       "type": "string"

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -1,12 +1,13 @@
-# The ID of your pipeline installation.
-# This can be found on the Pipeline Installations page in the Honeycomb UI.
-pipelineInstallationID: ""
-
 # The public ID of your Honeycomb Management API key.
 # See https://docs.honeycomb.io/configure/teams/manage-api-keys/#find-management-api-keys for more details.
 publicMgmtAPIKey: ""
 
 global:
+  # The ID of your pipeline installation.
+  # This can be found on the Pipeline Installations page in the Honeycomb UI.
+  pipeline:
+    id: ""
+
   # This setting configures the default endpoints. All endpoints can still be configured and will take precedence.
   # The default value is 'us1'.
   # Other valid values are:

--- a/tests/observability-pipeline/base-values.yaml
+++ b/tests/observability-pipeline/base-values.yaml
@@ -1,2 +1,4 @@
-pipelineInstallationID: test-installation-id
+global:
+  pipeline:
+    id: test-installation-id
 publicMgmtAPIKey: test-management-key-id


### PR DESCRIPTION
## Which problem is this PR solving?

Naming consistency for the helm values

- Closes https://github.com/honeycombio/pipeline-team/issues/416

## Short description of the changes

renamed `pipelineInstallationId` to `global.pipeline.id`

## How to verify that this has the expected result

Rendering shows no changes when the variable is moved in the values file.