### PR TITLE
feat(observability-pipeline): allow specifying config_apply_timeout

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.58-alpha
+version: 0.0.59-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -124,7 +124,7 @@ agent:
   config_files: 
     - {{ .Values.primaryCollector.agent.telemetry.file }}
   {{- end }}
-  config_apply_timeout: 10s
+  config_apply_timeout: {{ .Values.primaryCollector.agent.configApplyTimeout }}
   description:
     identifying_attributes:
       service.name: {{ .Values.primaryCollector.agent.telemetry.defaultServiceName }}

--- a/charts/observability-pipeline/values.schema.json
+++ b/charts/observability-pipeline/values.schema.json
@@ -231,6 +231,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "configApplyTimeout": {
+              "type": "string"
+            },
             "telemetry": {
               "type": "object",
               "additionalProperties": false,
@@ -252,7 +255,10 @@
                 }
               }
             }
-          }
+          },
+          "required": [
+            "configApplyTimeout"
+          ]
         },
         "opampsupervisor": {
           "type": "object",

--- a/charts/observability-pipeline/values.yaml
+++ b/charts/observability-pipeline/values.yaml
@@ -219,6 +219,7 @@ primaryCollector:
 
   # configuration options for the agent (a collector) the OpAMP Supervisor manages
   agent:
+    configApplyTimeout: 30s
     telemetry:
       enabled: true
       defaultEndpoint: ""

--- a/tests/observability-pipeline/rendered/rendered-customEndpoint.yaml
+++ b/tests/observability-pipeline/rendered/rendered-customEndpoint.yaml
@@ -233,7 +233,7 @@ data:
       executable: /otelcol-contrib
       config_files: 
         - /etc/agent/config.yaml
-      config_apply_timeout: 10s
+      config_apply_timeout: 30s
       description:
         identifying_attributes:
           service.name: primary-collector

--- a/tests/observability-pipeline/rendered/rendered-eu1.yaml
+++ b/tests/observability-pipeline/rendered/rendered-eu1.yaml
@@ -233,7 +233,7 @@ data:
       executable: /otelcol-contrib
       config_files: 
         - /etc/agent/config.yaml
-      config_apply_timeout: 10s
+      config_apply_timeout: 30s
       description:
         identifying_attributes:
           service.name: primary-collector

--- a/tests/observability-pipeline/rendered/rendered-unset-region.yaml
+++ b/tests/observability-pipeline/rendered/rendered-unset-region.yaml
@@ -224,7 +224,7 @@ data:
       executable: /otelcol-contrib
       config_files: 
         - /etc/agent/config.yaml
-      config_apply_timeout: 10s
+      config_apply_timeout: 30s
       description:
         identifying_attributes:
           service.name: primary-collector


### PR DESCRIPTION
## Which problem is this PR solving?

During testing we found that if the primary-collector has a lot of connections it takes longer to shutdown and startup during a rollout. The hard-coded 10s was causing rollouts to look like they failed.

## Short description of the changes

- update default value to 30s
- allow configuring value

## How to verify that this has the expected result

local templating
