### PR TITLE
feat(observability-pipeline): enable passthrough logs

### DIFF
--- a/charts/observability-pipeline/Chart.yaml
+++ b/charts/observability-pipeline/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: observability-pipeline
 description: Chart to deploy both OpenTelemetry Collector and Honeycomb Refinery
 type: application
-version: 0.0.59-alpha
+version: 0.0.60-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/observability-pipeline/templates/_helpers.tpl
+++ b/charts/observability-pipeline/templates/_helpers.tpl
@@ -124,6 +124,7 @@ agent:
   config_files: 
     - {{ .Values.primaryCollector.agent.telemetry.file }}
   {{- end }}
+  passthrough_logs: true
   config_apply_timeout: {{ .Values.primaryCollector.agent.configApplyTimeout }}
   description:
     identifying_attributes:


### PR DESCRIPTION
Enable the configuration to enable sending logs from the supervised collector through the supervisor.
