### PR TITLE
fix: move management api key into section

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.60-alpha
+version: 0.0.61-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/htp-builder/README.md
+++ b/charts/htp-builder/README.md
@@ -31,7 +31,7 @@ To install the chart with the release name `my-pipeline`, run the following comm
 ```shell
 helm install my-pipeline honeycomb/htp-builder \
     --set global.pipeline.id="pipeline-intallation-id" \
-    --set publicMgmtAPIKey="public-management-key-id"
+    --set managementApiKey.id="public-management-key-id"
 ```
 
 To uninstall the chart:

--- a/charts/htp-builder/templates/NOTES.txt
+++ b/charts/htp-builder/templates/NOTES.txt
@@ -14,12 +14,16 @@
   {{- fail ".global.pipeline.id must be set" }}
 {{- end }}
 
-{{- if (not .Values.publicMgmtAPIKey) }}
-  {{- fail "publicMgmtAPIKey must be set" }}
+{{- if (not .Values.managementApiKey.id) }}
+  {{- fail "managementApiKey.id must be set" }}
 {{- end }}
 
-{{- if (not .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content) }}
-  {{- fail "beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content must be set" }}
+{{- if (not .Values.managementApiKey.secret.name) }}
+  {{- fail "managementApiKey.secret.name must be set" }}
+{{- end }}
+
+{{- if (not .Values.managementApiKey.secret.key) }}
+  {{- fail "managementApiKey.secret.key must be set" }}
 {{- end }}
 
 {{- if (not .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content) }}

--- a/charts/htp-builder/templates/beekeeper-deployment.yaml
+++ b/charts/htp-builder/templates/beekeeper-deployment.yaml
@@ -61,9 +61,12 @@ spec:
             - name: HONEYCOMB_INSTALLATION_ID
               value: {{ .Values.global.pipeline.id }}
             - name: HONEYCOMB_MGMT_API_KEY
-              value: {{ .Values.publicMgmtAPIKey }}
+              value: {{ .Values.managementApiKey.id }}
             - name: HONEYCOMB_MGMT_API_SECRET
-              {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_MGMT_API_SECRET.content | nindent 14 }}  
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.managementApiKey.secret.name }}
+                  key: {{ .Values.managementApiKey.secret.key }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  
             {{- if .Values.beekeeper.defaultEnv.LOG_LEVEL.enabled }}

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -28,8 +28,26 @@
         }
       }
     },
-    "publicMgmtAPIKey": {
-      "type": "string"
+    "managementApiKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "refinery": {
       "type": "object"      

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -3,11 +3,11 @@
 managementApiKey:
   # The public ID of you mangement API key.
   id: ""
-  # The kubernetes secret used to provide secret the part of your management API key. 
+  # The kubernetes secret used to provide secret the part of your management API key.
   secret:
     # The name of the kubernetes secret
     name: "htp-builder"
-    # The key in the kubernetes secret that stores the secret the part of your management API key. 
+    # The key in the kubernetes secret that stores the secret the part of your management API key.
     key: "management-api-secret"
 
 global:

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -1,6 +1,14 @@
-# The public ID of your Honeycomb Management API key.
+# The Honeycomb Management API key used to authenticate and authorize your pipeline's interactions with Honeycomb.
 # See https://docs.honeycomb.io/configure/teams/manage-api-keys/#find-management-api-keys for more details.
-publicMgmtAPIKey: ""
+managementApiKey:
+  # The public ID of you mangement API key.
+  id: ""
+  # The kubernetes secret used to provide secret the part of your management API key. 
+  secret:
+    # The name of the kubernetes secret
+    name: "htp-builder"
+    # The key in the kubernetes secret that stores the secret the part of your management API key. 
+    key: "management-api-secret"
 
 global:
   # The ID of your pipeline installation.
@@ -66,12 +74,6 @@ beekeeper:
 
   # Allows configuring Beekeeper environment variables.
   defaultEnv:
-    HONEYCOMB_MGMT_API_SECRET:
-      content:
-        valueFrom:
-          secretKeyRef:
-            name: htp-builder
-            key: management-api-secret
     HONEYCOMB_API_KEY:
       content:
         valueFrom:

--- a/tests/htp-builder/base-values.yaml
+++ b/tests/htp-builder/base-values.yaml
@@ -1,4 +1,5 @@
 global:
   pipeline:
     id: test-installation-id
-publicMgmtAPIKey: test-management-key-id
+managementApiKey:
+  id: test-management-key-id

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -556,8 +556,8 @@ spec:
             - name: HONEYCOMB_MGMT_API_SECRET
               valueFrom:
                 secretKeyRef:
+                  name: htp-builder
                   key: management-api-secret
-                  name: htp-builder  
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -556,8 +556,8 @@ spec:
             - name: HONEYCOMB_MGMT_API_SECRET
               valueFrom:
                 secretKeyRef:
+                  name: htp-builder
                   key: management-api-secret
-                  name: htp-builder  
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -547,8 +547,8 @@ spec:
             - name: HONEYCOMB_MGMT_API_SECRET
               valueFrom:
                 secretKeyRef:
+                  name: htp-builder
                   key: management-api-secret
-                  name: htp-builder  
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/pipeline-team/issues/417

## Short description of the changes

- moves mangement api key management into its own section
- add comments
- update NOTES.txt checks
- update json schema
- remove unneeded default env var
- update beekeeper template to use new section

## How to verify that this has the expected result

test rendering
