### PR TITLE
maint(htp-builder): dont subchart refinery

### DIFF
--- a/charts/htp-builder/Chart.lock
+++ b/charts/htp-builder/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: refinery
-  repository: https://honeycombio.github.io/helm-charts
-  version: 2.17.0
-digest: sha256:13978ebf7edcd1c49266c9c1597442ce2a4a85774702048efd16ecd5738c333d
-generated: "2025-06-04T11:54:30.458257-06:00"

--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.61-alpha
+version: 0.0.62-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery
@@ -21,7 +21,3 @@ icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:
   - name: Honeycomb
     email: pipeline-team@honeycomb.io
-dependencies:
-- name: refinery
-  version: 2.17.0
-  repository: "https://honeycombio.github.io/helm-charts"

--- a/charts/htp-builder/templates/refinery-configmap-config.yaml
+++ b/charts/htp-builder/templates/refinery-configmap-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+data:
+  config.yaml: |
+  {{- include "htp-builder.refinery.config" . | nindent 4 -}}

--- a/charts/htp-builder/templates/refinery-configmap-rules.yaml
+++ b/charts/htp-builder/templates/refinery-configmap-rules.yaml
@@ -1,0 +1,15 @@
+{{ if not .Values.RulesConfigMapName }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery-rules
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+data:
+  rules.yaml: |
+  {{- include "htp-builder.refinery.rules" . | nindent 4 -}}
+
+{{ end }}

--- a/charts/htp-builder/templates/refinery-deployment-redis.yaml
+++ b/charts/htp-builder/templates/refinery-deployment-redis.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.refinery.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "htp-builder.refinery.redis.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "htp-builder.refinery.redis.labels" . | nindent 8 }}
+        app.kubernetes.io/component: refinery
+    spec:
+      serviceAccountName: {{ include "htp-builder.refinery.serviceAccountName" . }}
+      containers:
+        - name: redis
+          image: "{{ .Values.refinery.redis.image.repository }}:{{ .Values.refinery.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.refinery.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          {{- with .Values.refinery.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+  {{- end }}

--- a/charts/htp-builder/templates/refinery-deployment.yaml
+++ b/charts/htp-builder/templates/refinery-deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: {{ .Values.refinery.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "htp-builder.refinery.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/refinery-configmap-config.yaml") . | sha256sum }}
+        checksum/rules: {{ include (print $.Template.BasePath "/refinery-configmap-rules.yaml") . | sha256sum }}
+      labels:
+        {{- include "htp-builder.refinery.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "htp-builder.refinery.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.refinery.image.repository }}:{{ .Values.refinery.image.tag }}"
+          imagePullPolicy: {{ .Values.refinery.image.pullPolicy }}
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          {{- with .Values.refinery.extraEnvs }}
+          env:
+            {{- tpl (. | toYaml) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+            {{- with .Values.refinery.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            {{- with .Values.refinery.livenessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            {{- with .Values.refinery.readinessProbe }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.refinery.resources | nindent 12 }}
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ include "htp-builder.fullname" . }}-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: {{ include "htp-builder.fullname" . }}-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml
+        {{- with .Values.refinery.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/charts/htp-builder/templates/refinery-service-redis.yaml
+++ b/charts/htp-builder/templates/refinery-service-redis.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.refinery.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery-redis
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.redis.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+spec:
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    {{- include "htp-builder.refinery.redis.selectorLabels" . | nindent 6 }}
+{{- end}}

--- a/charts/htp-builder/templates/refinery-service.yaml
+++ b/charts/htp-builder/templates/refinery-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "htp-builder.fullname" . }}-refinery
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+spec:
+  ports:
+    - port: {{ .Values.refinery.service.port }}
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: {{ .Values.refinery.service.grpcPort }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
+  selector:
+    {{- include "htp-builder.refinery.selectorLabels" . | nindent 4 }}

--- a/charts/htp-builder/templates/refinery-serviceaccount.yaml
+++ b/charts/htp-builder/templates/refinery-serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.refinery.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "htp-builder.refinery.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "htp-builder.refinery.labels" . | nindent 4 }}
+    app.kubernetes.io/component: refinery
+{{- end }}

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -50,7 +50,148 @@
       }
     },
     "refinery": {
-      "type": "object"      
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The Refinery configuration",
+          "properties": {
+            "General": {
+              "type": "object",
+              "properties": {
+                "ConfigurationVersion": {
+                  "type": "integer"
+                },
+                "MinRefineryVersion": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "ConfigurationVersion",
+                "MinRefineryVersion"
+              ]
+            },
+            "Network": {
+              "type": "object"
+            },
+            "OpAMP": {
+              "type": "object"
+            },
+            "AccessKeys": {
+              "type": "object"
+            },
+            "RefineryTelemetry": {
+              "type": "object"
+            },
+            "Traces": {
+              "type": "object"
+            },
+            "Debugging": {
+              "type": "object"
+            },
+            "Logger": {
+              "type": "object"
+            },
+            "HoneycombLogger": {
+              "type": "object"
+            },
+            "StdoutLogger": {
+              "type": "object"
+            },
+            "PrometheusMetrics": {
+              "type": "object"
+            },
+            "LegacyMetrics": {
+              "type": "object"
+            },
+            "OTelMetrics": {
+              "type": "object"
+            },
+            "PeerManagement": {
+              "type": "object"
+            },
+            "RedisPeerManagement": {
+              "type": "object"
+            },
+            "Collection": {
+              "type": "object"
+            },
+            "BufferSizes": {
+              "type": "object"
+            },
+            "Specialized": {
+              "type": "object"
+            },
+            "IDFields": {
+              "type": "object"
+            },
+            "GRPCServerParameters": {
+              "type": "object"
+            },
+            "SampleCache": {
+              "type": "object"
+            },
+            "StressRelief": {
+              "type": "object"
+            },
+            "OTelTracing": {
+              "type": "object"
+            }
+          }
+        },
+        "rules": {
+          "type": "object",
+          "description": "The Refinery rules",
+          "properties": {
+            "RulesVersion": {
+              "type": "integer"
+            },
+            "Samplers": {
+              "type": "object",
+              "patternProperties": {
+                ".+": {
+                  "type": "object",
+                  "properties": {
+                    "RulesBasedSampler": {
+                      "type": "object",
+                      "properties": {
+                        "Rules": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "Conditions": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "Operator": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "Operator"
+                                  ]
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": [
+            "RulesVersion",
+            "Samplers"
+          ]
+        }
+      }
     },
     "beekeeper": {
       "type": "object",

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -36,18 +36,97 @@ global:
 # Configuration options for Refinery.
 # For a complete list of configuration options see https://github.com/honeycombio/helm-charts/tree/main/charts/refinery#configuration.
 refinery:
+  image:
+    repository: honeycombio/refinery
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "2.9.5"
   config:
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    PeerManagement:
+      Type: redis
+      # IdentifierInterfaceName specifies a network interface to use when finding a local hostname.
+      # Due to the nature of DNS in Kubernetes, it is recommended to set this value to the 'eth0' interface name.
+      # When configured the pod's IP will be used in the peer list
+      IdentifierInterfaceName: eth0
+    RedisPeerManagement:
+      # Host is the host and port of the Redis instance to use for peer cluster membership management.
+      Host: '{{include "htp-builder.fullname" .}}-refinery-redis:6379'
+    Collection:
+      ShutdownDelay: '{{ sub .Values.refinery.terminationGracePeriodSeconds 5 }}s'
+      # AvailableMemory is the amount of system memory available to the Refinery process.
+      AvailableMemory: '{{ .Values.refinery.resources.limits.memory }}'
+      MaxMemoryPercentage: 75
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
     OpAMP:
       Enabled: true
       Endpoint: "ws://{{ include \"htp-builder.beekeeperName\" . }}:4320/v1/opamp"
       RecordUsage: false
-    PrometheusMetrics:
-      Enabled: false
     OTelMetrics:
       Enabled: true
     Logger:
       Type: honeycomb
-  environment:
+
+  # Refinery rules.
+  # This section allows configuring Refinery rules.
+  # The default value is the bare minimum Refinery requires in order to run.
+  # It is highly recommend to set your own rules.
+  # When using the operators `>`, `>=` or `!=`, indicate that they are strings by enclosing them in single quotes, like ('>=').
+  # See https://docs.honeycomb.io/manage-data-volume/refinery/sampling-methods/ for how to configure Refinery rules.
+  rules:
+    RulesVersion: 2
+    Samplers: {}
+      # The default sampler is used when no other sampler matches.
+      # It is required to have a default sampler.
+      # If you do not supply a default sampler the helm chart will inject
+      # the DeterministicSampler shown below.
+      # __default__:
+      #     DeterministicSampler:
+      #         SampleRate: 1
+
+  ## Scaling Refinery ##
+  #
+  # Since Refinery is a stateful service we recommend provisioning refinery
+  # for your anticipated peak load and using Stress Relief to minimize impact
+  # from changes in cluster membership.
+  #
+  # Use replicaCount and resource limits to set the size of your Refinery cluster
+  # per your anticipated peak load.
+  # replicaCount is ignored if autoscaling is enabled
+  replicaCount: 3
+
+  resources:
+    limits:
+      cpu: 2000m
+      # This value is used by default for refinery.config.Collection.AvailableMemory
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+
+  # liveness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 3
+    timeoutSeconds: 1
+    failureThreshold: 3
+
+  # readiness probe configuration
+  # Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 1
+    timeoutSeconds: 1
+    failureThreshold: 1
+
+  extraEnvs:
     # Default key for the HPSF Honeycomb Exporter
     - name: HONEYCOMB_EXPORTER_APIKEY
       valueFrom:
@@ -60,6 +139,58 @@ refinery:
         secretKeyRef:
           name: htp-builder
           key: api-key
+
+  # Use to map additional volumes into the Refinery pods
+  # Useful for volume-based secrets
+  extraVolumeMounts: []
+    # - name: honeycomb-secrets
+    #   mountPath: "/mnt/secrets-store"
+    #   readOnly: true
+
+  # Use to map additional volumes into the Refinery pods
+  extraVolumes: []
+    # - name: honeycomb-secrets
+    #   csi:
+    #     driver: secrets-store.csi.k8s.io
+    #     readOnly: true
+    #     volumeAttributes:
+    #       secretProviderClass: "honeycomb-secrets"
+
+  # Redis configuration
+  redis:
+    # To install a simple single pod Redis deployment set this to true.
+    # If false, you must specify a value for existingHost
+    # For production, it is recommended to set this to false and provide
+    # a highly available Redis configuration using redis.existingHost
+    enabled: true
+
+    # If redis.enabled is true, this the image that will be used to create
+    # the Redis deployment
+    image:
+      repository: redis
+      tag: 7.2
+      pullPolicy: IfNotPresent
+
+    resources: {}
+      # limits:
+      #   cpu: 500m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 50Mi
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+
+  service:
+    port: 80
+    grpcPort: 4317
+  
+  terminationGracePeriodSeconds: 35
 
 # Configuration options for Beekeeper.
 beekeeper:
@@ -213,7 +344,7 @@ primaryCollector:
       content:
         # If you change the refinery service name via refinery.nameOverride or refinery.fullnameOverride
         # you'll need to change this value too.
-        value: '{{ include "htp-builder.refineryName" . }}'
+        value: '{{ include "htp-builder.fullname" . }}-refinery'
   extraEnvs: []
 
   volumes: []

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -1,15 +1,4 @@
 ---
-# Source: htp-builder/charts/refinery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: test-refinery
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
----
 # Source: htp-builder/templates/beekeeper-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -34,76 +23,17 @@ metadata:
     app.kubernetes.io/version: "0.0.1-alpha"
     app.kubernetes.io/component: collector
 ---
-# Source: htp-builder/charts/refinery/templates/configmap-config.yaml
+# Source: htp-builder/templates/refinery-serviceaccount.yaml
 apiVersion: v1
-kind: ConfigMap
+kind: ServiceAccount
 metadata:
-  name: test-refinery-config
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  config.yaml: |
-    Collection:
-      AvailableMemory: '2Gi'
-      MaxMemoryPercentage: 75
-      ShutdownDelay: '30s'
-    Debugging:
-      AdditionalErrorFields:
-      - trace.span_id
-    GRPCServerParameters:
-      Enabled: true
-      ListenAddr: 0.0.0.0:4317
-    General:
-      ConfigurationVersion: 2
-      MinRefineryVersion: v2.0
-    HoneycombLogger:
-      APIHost: https://this.is.a.test
-    LegacyMetrics:
-      APIHost: https://this.is.a.test
-    Logger:
-      Type: honeycomb
-    Network:
-      HoneycombAPI: https://this.is.a.test
-    OTelMetrics:
-      APIHost: https://this.is.a.test
-      Enabled: true
-    OTelTracing:
-      APIHost: https://this.is.a.test
-    OpAMP:
-      Enabled: true
-      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
-      RecordUsage: false
-    PeerManagement:
-      IdentifierInterfaceName: eth0
-      Type: redis
-    PrometheusMetrics:
-      Enabled: false
-      ListenAddr: 0.0.0.0:9090
-    RedisPeerManagement:
-      Host: 'test-refinery-redis:6379'
-    RefineryTelemetry:
-      AddRuleReasonToTrace: true
----
-# Source: htp-builder/charts/refinery/templates/configmap-rules.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-refinery-rules
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  rules.yaml: |
-    RulesVersion: 2
-    Samplers:
-      __default__:
-        DeterministicSampler:
-          SampleRate: 1
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 ---
 # Source: htp-builder/templates/beekeeper-configmap-otel.yaml
 apiVersion: v1
@@ -258,52 +188,72 @@ data:
       resource:
         service.name: 'opamp-supervisor'
 ---
-# Source: htp-builder/charts/refinery/templates/service-redis.yaml
+# Source: htp-builder/templates/refinery-configmap-config.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-config
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - name: tcp-redis
-      port: 6379
-      protocol: TCP
-      targetPort: redis
-  selector:
-    app.kubernetes.io/name: refinery-redis
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://this.is.a.test
+    LegacyMetrics:
+      APIHost: https://this.is.a.test
+    Logger:
+      Type: honeycomb
+    Network:
+      HoneycombAPI: https://this.is.a.test
+    OTelMetrics:
+      APIHost: https://this.is.a.test
+      Enabled: true
+    OTelTracing:
+      APIHost: https://this.is.a.test
+    OpAMP:
+      Enabled: true
+      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
+      RecordUsage: false
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    RedisPeerManagement:
+      Host: 'test-htp-builder-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
 ---
-# Source: htp-builder/charts/refinery/templates/service.yaml
+# Source: htp-builder/templates/refinery-configmap-rules.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery-rules
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: data
-      protocol: TCP
-      name: data
-    - port: 4317
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-
-  selector:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
 ---
 # Source: htp-builder/templates/beekeeper-service.yaml
 apiVersion: v1
@@ -354,144 +304,52 @@ spec:
     app.kubernetes.io/name: test-primary-collector
     app.kubernetes.io/instance: test
 ---
-# Source: htp-builder/charts/refinery/templates/deployment-redis.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service-redis.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-redis
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 1
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/name: test-redis
       app.kubernetes.io/instance: test
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: refinery-redis
-        app.kubernetes.io/instance: test
-    spec:
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: redis
-          securityContext:
-            {}
-          image: "redis:7.2"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: redis
-              containerPort: 6379
-              protocol: TCP
 ---
-# Source: htp-builder/charts/refinery/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 3
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery
-      app.kubernetes.io/instance: test
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-      labels:
-        app.kubernetes.io/name: refinery
-        app.kubernetes.io/instance: test
-    spec:
-      terminationGracePeriodSeconds: 35
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: refinery
-          securityContext:
-            {}
-          image: "honeycombio/refinery:2.9.5"
-          imagePullPolicy: IfNotPresent
-          command:
-            - refinery
-            - -c
-            - /etc/refinery/config.yaml
-            - -r
-            - /etc/refinery/rules.yaml
-          env:
-            - name: HONEYCOMB_EXPORTER_APIKEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-            - name: REFINERY_HONEYCOMB_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-          ports:
-            - name: data
-              containerPort: 8080
-              protocol: TCP
-            - name: grpc
-              containerPort: 4317
-              protocol: TCP
-            - name: peer
-              containerPort: 8081
-              protocol: TCP
-          volumeMounts:
-            - name: refinery-config
-              mountPath: /etc/refinery/
-          livenessProbe:
-            httpGet:
-              path: /alive
-              port: data
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: data
-            failureThreshold: 1
-            initialDelaySeconds: 5
-            periodSeconds: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 500m
-              memory: 500Mi
-      volumes:
-        - name: refinery-config
-          projected:
-            sources:
-              - configMap:
-                  name: test-refinery-config
-                  items:
-                    - key: config.yaml
-                      path: config.yaml
-              - configMap:
-                  name: test-refinery-rules
-                  items:
-                    - key: rules.yaml
-                      path: rules.yaml
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
 ---
 # Source: htp-builder/templates/beekeeper-deployment.yaml
 apiVersion: apps/v1
@@ -646,7 +504,7 @@ spec:
                   key: api-key
                   name: htp-builder
             - name: STRAWS_REFINERY_SERVICE
-              value: 'test-refinery'
+              value: 'test-htp-builder-refinery'
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor
@@ -665,3 +523,135 @@ spec:
             items:
               - key: config
                 path: config.yaml
+---
+# Source: htp-builder/templates/refinery-deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-redis
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/version: "0.0.1-alpha"
+        app.kubernetes.io/component: refinery
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: htp-builder/templates/refinery-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-refinery
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-refinery
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: htp-builder
+          image: "honeycombio/refinery:"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          env:
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+            - name: REFINERY_HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-htp-builder-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-htp-builder-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -1,15 +1,4 @@
 ---
-# Source: htp-builder/charts/refinery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: test-refinery
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
----
 # Source: htp-builder/templates/beekeeper-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -34,76 +23,17 @@ metadata:
     app.kubernetes.io/version: "0.0.1-alpha"
     app.kubernetes.io/component: collector
 ---
-# Source: htp-builder/charts/refinery/templates/configmap-config.yaml
+# Source: htp-builder/templates/refinery-serviceaccount.yaml
 apiVersion: v1
-kind: ConfigMap
+kind: ServiceAccount
 metadata:
-  name: test-refinery-config
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  config.yaml: |
-    Collection:
-      AvailableMemory: '2Gi'
-      MaxMemoryPercentage: 75
-      ShutdownDelay: '30s'
-    Debugging:
-      AdditionalErrorFields:
-      - trace.span_id
-    GRPCServerParameters:
-      Enabled: true
-      ListenAddr: 0.0.0.0:4317
-    General:
-      ConfigurationVersion: 2
-      MinRefineryVersion: v2.0
-    HoneycombLogger:
-      APIHost: https://api.eu1.honeycomb.io
-    LegacyMetrics:
-      APIHost: https://api.eu1.honeycomb.io
-    Logger:
-      Type: honeycomb
-    Network:
-      HoneycombAPI: https://api.eu1.honeycomb.io
-    OTelMetrics:
-      APIHost: https://api.eu1.honeycomb.io
-      Enabled: true
-    OTelTracing:
-      APIHost: https://api.eu1.honeycomb.io
-    OpAMP:
-      Enabled: true
-      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
-      RecordUsage: false
-    PeerManagement:
-      IdentifierInterfaceName: eth0
-      Type: redis
-    PrometheusMetrics:
-      Enabled: false
-      ListenAddr: 0.0.0.0:9090
-    RedisPeerManagement:
-      Host: 'test-refinery-redis:6379'
-    RefineryTelemetry:
-      AddRuleReasonToTrace: true
----
-# Source: htp-builder/charts/refinery/templates/configmap-rules.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-refinery-rules
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  rules.yaml: |
-    RulesVersion: 2
-    Samplers:
-      __default__:
-        DeterministicSampler:
-          SampleRate: 1
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 ---
 # Source: htp-builder/templates/beekeeper-configmap-otel.yaml
 apiVersion: v1
@@ -258,52 +188,72 @@ data:
       resource:
         service.name: 'opamp-supervisor'
 ---
-# Source: htp-builder/charts/refinery/templates/service-redis.yaml
+# Source: htp-builder/templates/refinery-configmap-config.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-config
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - name: tcp-redis
-      port: 6379
-      protocol: TCP
-      targetPort: redis
-  selector:
-    app.kubernetes.io/name: refinery-redis
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    HoneycombLogger:
+      APIHost: https://api.eu1.honeycomb.io
+    LegacyMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+    Logger:
+      Type: honeycomb
+    Network:
+      HoneycombAPI: https://api.eu1.honeycomb.io
+    OTelMetrics:
+      APIHost: https://api.eu1.honeycomb.io
+      Enabled: true
+    OTelTracing:
+      APIHost: https://api.eu1.honeycomb.io
+    OpAMP:
+      Enabled: true
+      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
+      RecordUsage: false
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    RedisPeerManagement:
+      Host: 'test-htp-builder-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
 ---
-# Source: htp-builder/charts/refinery/templates/service.yaml
+# Source: htp-builder/templates/refinery-configmap-rules.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery-rules
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: data
-      protocol: TCP
-      name: data
-    - port: 4317
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-
-  selector:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
 ---
 # Source: htp-builder/templates/beekeeper-service.yaml
 apiVersion: v1
@@ -354,144 +304,52 @@ spec:
     app.kubernetes.io/name: test-primary-collector
     app.kubernetes.io/instance: test
 ---
-# Source: htp-builder/charts/refinery/templates/deployment-redis.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service-redis.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-redis
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 1
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/name: test-redis
       app.kubernetes.io/instance: test
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: refinery-redis
-        app.kubernetes.io/instance: test
-    spec:
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: redis
-          securityContext:
-            {}
-          image: "redis:7.2"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: redis
-              containerPort: 6379
-              protocol: TCP
 ---
-# Source: htp-builder/charts/refinery/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 3
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery
-      app.kubernetes.io/instance: test
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-      labels:
-        app.kubernetes.io/name: refinery
-        app.kubernetes.io/instance: test
-    spec:
-      terminationGracePeriodSeconds: 35
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: refinery
-          securityContext:
-            {}
-          image: "honeycombio/refinery:2.9.5"
-          imagePullPolicy: IfNotPresent
-          command:
-            - refinery
-            - -c
-            - /etc/refinery/config.yaml
-            - -r
-            - /etc/refinery/rules.yaml
-          env:
-            - name: HONEYCOMB_EXPORTER_APIKEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-            - name: REFINERY_HONEYCOMB_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-          ports:
-            - name: data
-              containerPort: 8080
-              protocol: TCP
-            - name: grpc
-              containerPort: 4317
-              protocol: TCP
-            - name: peer
-              containerPort: 8081
-              protocol: TCP
-          volumeMounts:
-            - name: refinery-config
-              mountPath: /etc/refinery/
-          livenessProbe:
-            httpGet:
-              path: /alive
-              port: data
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: data
-            failureThreshold: 1
-            initialDelaySeconds: 5
-            periodSeconds: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 500m
-              memory: 500Mi
-      volumes:
-        - name: refinery-config
-          projected:
-            sources:
-              - configMap:
-                  name: test-refinery-config
-                  items:
-                    - key: config.yaml
-                      path: config.yaml
-              - configMap:
-                  name: test-refinery-rules
-                  items:
-                    - key: rules.yaml
-                      path: rules.yaml
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
 ---
 # Source: htp-builder/templates/beekeeper-deployment.yaml
 apiVersion: apps/v1
@@ -646,7 +504,7 @@ spec:
                   key: api-key
                   name: htp-builder
             - name: STRAWS_REFINERY_SERVICE
-              value: 'test-refinery'
+              value: 'test-htp-builder-refinery'
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor
@@ -665,3 +523,135 @@ spec:
             items:
               - key: config
                 path: config.yaml
+---
+# Source: htp-builder/templates/refinery-deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-redis
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/version: "0.0.1-alpha"
+        app.kubernetes.io/component: refinery
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: htp-builder/templates/refinery-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-refinery
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-refinery
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: htp-builder
+          image: "honeycombio/refinery:"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          env:
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+            - name: REFINERY_HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-htp-builder-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-htp-builder-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -1,15 +1,4 @@
 ---
-# Source: htp-builder/charts/refinery/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: test-refinery
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
----
 # Source: htp-builder/templates/beekeeper-serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -34,67 +23,17 @@ metadata:
     app.kubernetes.io/version: "0.0.1-alpha"
     app.kubernetes.io/component: collector
 ---
-# Source: htp-builder/charts/refinery/templates/configmap-config.yaml
+# Source: htp-builder/templates/refinery-serviceaccount.yaml
 apiVersion: v1
-kind: ConfigMap
+kind: ServiceAccount
 metadata:
-  name: test-refinery-config
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  config.yaml: |
-    Collection:
-      AvailableMemory: '2Gi'
-      MaxMemoryPercentage: 75
-      ShutdownDelay: '30s'
-    Debugging:
-      AdditionalErrorFields:
-      - trace.span_id
-    GRPCServerParameters:
-      Enabled: true
-      ListenAddr: 0.0.0.0:4317
-    General:
-      ConfigurationVersion: 2
-      MinRefineryVersion: v2.0
-    Logger:
-      Type: honeycomb
-    OTelMetrics:
-      Enabled: true
-    OpAMP:
-      Enabled: true
-      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
-      RecordUsage: false
-    PeerManagement:
-      IdentifierInterfaceName: eth0
-      Type: redis
-    PrometheusMetrics:
-      Enabled: false
-      ListenAddr: 0.0.0.0:9090
-    RedisPeerManagement:
-      Host: 'test-refinery-redis:6379'
-    RefineryTelemetry:
-      AddRuleReasonToTrace: true
----
-# Source: htp-builder/charts/refinery/templates/configmap-rules.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: test-refinery-rules
-  namespace: default
-  labels:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-data:
-  rules.yaml: |
-    RulesVersion: 2
-    Samplers:
-      __default__:
-        DeterministicSampler:
-          SampleRate: 1
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 ---
 # Source: htp-builder/templates/beekeeper-configmap-otel.yaml
 apiVersion: v1
@@ -249,52 +188,63 @@ data:
       resource:
         service.name: 'opamp-supervisor'
 ---
-# Source: htp-builder/charts/refinery/templates/service-redis.yaml
+# Source: htp-builder/templates/refinery-configmap-config.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-config
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - name: tcp-redis
-      port: 6379
-      protocol: TCP
-      targetPort: redis
-  selector:
-    app.kubernetes.io/name: refinery-redis
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  config.yaml: |
+    Collection:
+      AvailableMemory: '2Gi'
+      MaxMemoryPercentage: 75
+      ShutdownDelay: '30s'
+    GRPCServerParameters:
+      Enabled: true
+      ListenAddr: 0.0.0.0:4317
+    General:
+      ConfigurationVersion: 2
+      MinRefineryVersion: v2.0
+    Logger:
+      Type: honeycomb
+    OTelMetrics:
+      Enabled: true
+    OpAMP:
+      Enabled: true
+      Endpoint: ws://test-htp-builder-beekeeper:4320/v1/opamp
+      RecordUsage: false
+    PeerManagement:
+      IdentifierInterfaceName: eth0
+      Type: redis
+    RedisPeerManagement:
+      Host: 'test-htp-builder-refinery-redis:6379'
+    RefineryTelemetry:
+      AddRuleReasonToTrace: true
 ---
-# Source: htp-builder/charts/refinery/templates/service.yaml
+# Source: htp-builder/templates/refinery-configmap-rules.yaml
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery-rules
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 80
-      targetPort: data
-      protocol: TCP
-      name: data
-    - port: 4317
-      targetPort: grpc
-      protocol: TCP
-      name: grpc
-
-  selector:
-    app.kubernetes.io/name: refinery
-    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+data:
+  rules.yaml: |
+    RulesVersion: 2
+    Samplers:
+      __default__:
+        DeterministicSampler:
+          SampleRate: 1
 ---
 # Source: htp-builder/templates/beekeeper-service.yaml
 apiVersion: v1
@@ -345,144 +295,52 @@ spec:
     app.kubernetes.io/name: test-primary-collector
     app.kubernetes.io/instance: test
 ---
-# Source: htp-builder/charts/refinery/templates/deployment-redis.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service-redis.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery-redis
+  name: test-htp-builder-refinery-redis
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery-redis
+    app.kubernetes.io/name: test-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 1
+  type: ClusterIP
+  ports:
+    - name: tcp-redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery-redis
+      app.kubernetes.io/name: test-redis
       app.kubernetes.io/instance: test
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: refinery-redis
-        app.kubernetes.io/instance: test
-    spec:
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: redis
-          securityContext:
-            {}
-          image: "redis:7.2"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: redis
-              containerPort: 6379
-              protocol: TCP
 ---
-# Source: htp-builder/charts/refinery/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
+# Source: htp-builder/templates/refinery-service.yaml
+apiVersion: v1
+kind: Service
 metadata:
-  name: test-refinery
+  name: test-htp-builder-refinery
   namespace: default
   labels:
-    app.kubernetes.io/name: refinery
+    app.kubernetes.io/name: test-refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
 spec:
-  replicas: 3
+  ports:
+    - port: 80
+      targetPort: data
+      protocol: TCP
+      name: data
+    - port: 4317
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
-    matchLabels:
-      app.kubernetes.io/name: refinery
-      app.kubernetes.io/instance: test
-  strategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-      labels:
-        app.kubernetes.io/name: refinery
-        app.kubernetes.io/instance: test
-    spec:
-      terminationGracePeriodSeconds: 35
-      serviceAccountName: test-refinery
-      securityContext:
-        {}
-      containers:
-        - name: refinery
-          securityContext:
-            {}
-          image: "honeycombio/refinery:2.9.5"
-          imagePullPolicy: IfNotPresent
-          command:
-            - refinery
-            - -c
-            - /etc/refinery/config.yaml
-            - -r
-            - /etc/refinery/rules.yaml
-          env:
-            - name: HONEYCOMB_EXPORTER_APIKEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-            - name: REFINERY_HONEYCOMB_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: api-key
-                  name: htp-builder
-          ports:
-            - name: data
-              containerPort: 8080
-              protocol: TCP
-            - name: grpc
-              containerPort: 4317
-              protocol: TCP
-            - name: peer
-              containerPort: 8081
-              protocol: TCP
-          volumeMounts:
-            - name: refinery-config
-              mountPath: /etc/refinery/
-          livenessProbe:
-            httpGet:
-              path: /alive
-              port: data
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            timeoutSeconds: 1
-          readinessProbe:
-            httpGet:
-              path: /ready
-              port: data
-            failureThreshold: 1
-            initialDelaySeconds: 5
-            periodSeconds: 1
-            timeoutSeconds: 1
-          resources:
-            limits:
-              cpu: 2000m
-              memory: 2Gi
-            requests:
-              cpu: 500m
-              memory: 500Mi
-      volumes:
-        - name: refinery-config
-          projected:
-            sources:
-              - configMap:
-                  name: test-refinery-config
-                  items:
-                    - key: config.yaml
-                      path: config.yaml
-              - configMap:
-                  name: test-refinery-rules
-                  items:
-                    - key: rules.yaml
-                      path: rules.yaml
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
 ---
 # Source: htp-builder/templates/beekeeper-deployment.yaml
 apiVersion: apps/v1
@@ -637,7 +495,7 @@ spec:
                   key: api-key
                   name: htp-builder
             - name: STRAWS_REFINERY_SERVICE
-              value: 'test-refinery'
+              value: 'test-htp-builder-refinery'
           volumeMounts:
             - name: config
               mountPath: /etc/opampsupervisor
@@ -656,3 +514,135 @@ spec:
             items:
               - key: config
                 path: config.yaml
+---
+# Source: htp-builder/templates/refinery-deployment-redis.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery-redis
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-redis
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-redis
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-redis
+        app.kubernetes.io/instance: test
+        app.kubernetes.io/version: "0.0.1-alpha"
+        app.kubernetes.io/component: refinery
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: redis
+          image: "redis:7.2"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+---
+# Source: htp-builder/templates/refinery-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-htp-builder-refinery
+  namespace: default
+  labels:
+    app.kubernetes.io/name: test-refinery
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "0.0.1-alpha"
+    app.kubernetes.io/component: refinery
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-refinery
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: test-refinery
+        app.kubernetes.io/instance: test
+    spec:
+      serviceAccountName: test-htp-builder-refinery
+      containers:
+        - name: htp-builder
+          image: "honeycombio/refinery:"
+          imagePullPolicy: IfNotPresent
+          command:
+            - refinery
+            - -c
+            - /etc/refinery/config.yaml
+            - -r
+            - /etc/refinery/rules.yaml
+          env:
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+            - name: REFINERY_HONEYCOMB_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: api-key
+                  name: htp-builder
+          ports:
+            - name: data
+              containerPort: 8080
+              protocol: TCP
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: peer
+              containerPort: 8081
+              protocol: TCP
+          volumeMounts:
+            - name: refinery-config
+              mountPath: /etc/refinery/
+          livenessProbe:
+            httpGet:
+              path: /alive
+              port: data
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: data
+            failureThreshold: 1
+            initialDelaySeconds: 5
+            periodSeconds: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 500m
+              memory: 500Mi
+      volumes:
+        - name: refinery-config
+          projected:
+            sources:
+              - configMap:
+                  name: test-htp-builder-refinery-config
+                  items:
+                    - key: config.yaml
+                      path: config.yaml
+              - configMap:
+                  name: test-htp-builder-refinery-rules
+                  items:
+                    - key: rules.yaml
+                      path: rules.yaml


### PR DESCRIPTION
## Which problem is this PR solving?

Switch htp-build to install refinery itself instead of relying on the refinery subchart. This will give us greater control over the refinery install, especially when trying to configure refinery env vars and other properties based on root values from the chart.

## How to verify that this has the expected result

installed via sippycup
