### PR TITLE
maint(htp-builder): remove global section

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.63-alpha
+version: 0.0.64-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/htp-builder/README.md
+++ b/charts/htp-builder/README.md
@@ -30,7 +30,7 @@ To install the chart with the release name `my-pipeline`, run the following comm
 
 ```shell
 helm install my-pipeline honeycomb/htp-builder \
-    --set global.pipeline.id="pipeline-intallation-id" \
+    --set pipeline.id="pipeline-intallation-id" \
     --set managementApiKey.id="public-management-key-id"
 ```
 

--- a/charts/htp-builder/templates/NOTES.txt
+++ b/charts/htp-builder/templates/NOTES.txt
@@ -10,8 +10,8 @@
   {{- fail "beekeeper.image.tag must be set" }}
 {{- end }}
 
-{{- if (not .Values.global.pipeline.id) }}
-  {{- fail ".global.pipeline.id must be set" }}
+{{- if (not .Values.pipeline.id) }}
+  {{- fail ".pipeline.id must be set" }}
 {{- end }}
 
 {{- if (not .Values.managementApiKey.id) }}

--- a/charts/htp-builder/templates/_helpers.tpl
+++ b/charts/htp-builder/templates/_helpers.tpl
@@ -9,9 +9,9 @@ Expand the name of the chart.
 Get the api base URL
 */}}
 {{- define "htp-builder.apiBaseUrl" -}}
-{{- if and (ne .Values.global.customEndpoint "") (.Values.global.customEndpoint) }}
-{{- default .Values.global.customEndpoint }}
-{{- else if or (eq .Values.global.region "production-eu") (eq .Values.global.region "eu1") }}
+{{- if and (ne .Values.region.customEndpoint "") (.Values.region.customEndpoint) }}
+{{- default .Values.region.customEndpoint }}
+{{- else if or (eq .Values.region.id "production-eu") (eq .Values.region.id "eu1") }}
 {{- default "https://api.eu1.honeycomb.io"  }}
 {{- else }}
 {{- default "https://api.honeycomb.io" }}
@@ -261,11 +261,11 @@ Build config file for Refinery
 */}}
 {{- define "htp-builder.refinery.config" -}}
 {{- $config := deepCopy .Values.refinery.config }}
-{{- if eq .Values.global.region "eu1" }}
+{{- if eq .Values.region.id "eu1" }}
 {{- $config = mustMergeOverwrite (include "htp-builder.refinery.productionEU1Config" .Values | fromYaml) $config }}
 {{- end }}
-{{- if eq .Values.global.region "custom" }}
-{{- $customEndpoint := (.Values.global.customEndpoint | trimSuffix "/") }}
+{{- if eq .Values.region.id "custom" }}
+{{- $customEndpoint := (.Values.region.customEndpoint | trimSuffix "/") }}
 {{- $config = mustMergeOverwrite (include "htp-builder.refinery.customConfig" $customEndpoint | fromYaml) $config }}
 {{- end }}
 {{- tpl (toYaml $config) . }}

--- a/charts/htp-builder/templates/beekeeper-deployment.yaml
+++ b/charts/htp-builder/templates/beekeeper-deployment.yaml
@@ -55,11 +55,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipeline.id={{ .Values.global.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: HONEYCOMB_API
               value: {{ include "htp-builder.beekeeper.endpoint" . }}
             - name: HONEYCOMB_INSTALLATION_ID
-              value: {{ .Values.global.pipeline.id }}
+              value: {{ .Values.pipeline.id }}
             - name: HONEYCOMB_MGMT_API_KEY
               value: {{ .Values.managementApiKey.id }}
             - name: HONEYCOMB_MGMT_API_SECRET

--- a/charts/htp-builder/templates/primary-collector-deployment.yaml
+++ b/charts/htp-builder/templates/primary-collector-deployment.yaml
@@ -54,7 +54,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipeline.id={{ .Values.global.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             {{- if .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  

--- a/charts/htp-builder/templates/refinery-deployment.yaml
+++ b/charts/htp-builder/templates/refinery-deployment.yaml
@@ -52,7 +52,7 @@ spec:
                 fieldRef:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
-              value: pipeline.id={{ .Values.global.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+              value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             {{- with .Values.refinery.extraEnvs }}
               {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -7,19 +7,20 @@
     "enabled": {
       "type": "boolean"
     },
-    "global": {
+    "pipeline": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
-        "pipeline": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "id": {
-              "type": "string"
-            }
-          }
-        },
-        "region": {
+        "id": {
+          "type": "string"
+        }
+      }
+    },
+    "region": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
           "type": "string",
           "enum": ["us1", "eu1", "custom"]
         },

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -1,3 +1,8 @@
+# The ID of your pipeline installation.
+# This can be found on the Pipeline Installations page in the Honeycomb UI.
+pipeline:
+  id: ""
+
 # The Honeycomb Management API key used to authenticate and authorize your pipeline's interactions with Honeycomb.
 # See https://docs.honeycomb.io/configure/teams/manage-api-keys/#find-management-api-keys for more details.
 managementApiKey:
@@ -10,23 +15,17 @@ managementApiKey:
     # The key in the kubernetes secret that stores the secret the part of your management API key.
     key: "management-api-secret"
 
-global:
-  # The ID of your pipeline installation.
-  # This can be found on the Pipeline Installations page in the Honeycomb UI.
-  pipeline:
-    id: ""
-
-  # This setting configures the default endpoints. All endpoints can still be configured and will take precedence.
-  # The default value is 'us1'.
+# This setting configures regional configuration (like endpoints) across all artifacts.
+# Artifact-specific configuration is still supported and will take precedence.
+region:
+  # The default id is 'us1'.
   # Other valid values are:
   #  - eu1
   #  - custom
   #
   # When 'us1' is selected, the endpoints for all services are set to https://api.honeycomb.io.
   # When 'eu1' is selected, the endpoints for all services are set to https://api.eu1.honeycomb.io.
-  #
-  # Any values you've configured will take precedence.
-  region: "us1"
+  id: "us1"
 
   # This setting will override any regional setting applied.
   # You must not include the trailing slash, this must only be a domain and protocol (e.g. https://api.honeycomb.io).

--- a/tests/htp-builder/base-values.yaml
+++ b/tests/htp-builder/base-values.yaml
@@ -1,5 +1,4 @@
-global:
-  pipeline:
-    id: test-installation-id
+pipeline:
+  id: test-installation-id
 managementApiKey:
   id: test-management-key-id

--- a/tests/htp-builder/tests/customEndpoint.yaml
+++ b/tests/htp-builder/tests/customEndpoint.yaml
@@ -1,3 +1,3 @@
-global:
-  region: custom
+region:
+  id: custom
   customEndpoint: https://this.is.a.test

--- a/tests/htp-builder/tests/eu1.yaml
+++ b/tests/htp-builder/tests/eu1.yaml
@@ -1,2 +1,2 @@
-global:
-  region: eu1
+region:
+  id: eu1


### PR DESCRIPTION
## Which problem is this PR solving?

Since I removed the refinery subchart we don't need to use the global section anymore.

- related to https://github.com/honeycombio/pipeline-team/issues/415

## Short description of the changes

- remove the global section
- update all templates
- reorganize `region` section to follow `<section>.id` pattern

## How to verify that this has the expected result

test and local template.
