### PR TITLE
feat(htp-builder): simpler key configuration

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.64-alpha
+version: 0.0.65-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/htp-builder/templates/NOTES.txt
+++ b/charts/htp-builder/templates/NOTES.txt
@@ -26,10 +26,13 @@
   {{- fail "managementApiKey.secret.key must be set" }}
 {{- end }}
 
+{{- if and (not .Values.ingestKey.value) (or (not .Values.ingestKey.secret.name) (not .Values.ingestKey.secret.key)) }}
+  {{- fail "an ingest key must be provided via ingestKey.value or ingestKey.secret" }}
+{{- end }}
+
 {{- if (not .Values.beekeeper.defaultEnv.HONEYCOMB_API_KEY.content) }}
   {{- fail "beekeeper.defaultEnv.HONEYCOMB_API_KEY.content must be set" }}
 {{- end }}
-
 
 {{- if (not .Values.primaryCollector.image.repository) }}
   {{- fail "collector.image.repository must be set" }}
@@ -38,7 +41,6 @@
 {{- if (not .Values.primaryCollector.image.tag) }}
   {{- fail "collector.image.tag must be set" }}
 {{- end }}
-
 
 Your Honeycomb Telemetry Pipeline Builder is ready.
 

--- a/charts/htp-builder/templates/primary-collector-deployment.yaml
+++ b/charts/htp-builder/templates/primary-collector-deployment.yaml
@@ -55,6 +55,15 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              {{- if .Values.ingestKey.value }}
+              value: {{ .Values.ingestKey.value }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ingestKey.secret.name }}
+                  key: {{ .Values.ingestKey.secret.key }}
+              {{- end }}
             {{- if .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.enabled }}
             - name: HONEYCOMB_API_KEY
               {{- toYaml .Values.primaryCollector.defaultEnv.HONEYCOMB_API_KEY.content | nindent 14 }}  

--- a/charts/htp-builder/templates/refinery-deployment.yaml
+++ b/charts/htp-builder/templates/refinery-deployment.yaml
@@ -53,6 +53,15 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              {{- if .Values.ingestKey.value }}
+              value: {{ .Values.ingestKey.value }}
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ingestKey.secret.name }}
+                  key: {{ .Values.ingestKey.secret.key }}
+              {{- end }}
             {{- with .Values.refinery.extraEnvs }}
               {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -16,6 +16,27 @@
         }
       }
     },
+    "ingestKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "region": {
       "type": "object",
       "additionalProperties": false,

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -15,6 +15,17 @@ managementApiKey:
     # The key in the kubernetes secret that stores the secret the part of your management API key.
     key: "management-api-secret"
 
+# The Honeycomb ingest key used to export the received data.
+ingestKey:
+  # The key may be provided directly, although this is not secure and not recommended
+  value: ""
+  # The recommend way to supply the ingest key is via a kubernetes secret
+  secret:
+    # The name of the kubernetes secret providing the ingest key
+    name: "htp-builder"
+    # The name of the field in the secret which stores the ingest key
+    key: "api-key"
+
 # This setting configures regional configuration (like endpoints) across all artifacts.
 # Artifact-specific configuration is still supported and will take precedence.
 region:
@@ -126,12 +137,6 @@ refinery:
     failureThreshold: 1
 
   extraEnvs:
-    # Default key for the HPSF Honeycomb Exporter
-    - name: HONEYCOMB_EXPORTER_APIKEY
-      valueFrom:
-        secretKeyRef:
-          name: htp-builder
-          key: api-key
     # Env var for exporting refinery internal telemetry
     - name: REFINERY_HONEYCOMB_API_KEY
       valueFrom:

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -498,6 +498,11 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: htp-builder
+                  key: api-key
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -620,8 +625,8 @@ spec:
             - name: HONEYCOMB_EXPORTER_APIKEY
               valueFrom:
                 secretKeyRef:
-                  key: api-key
                   name: htp-builder
+                  key: api-key
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -498,6 +498,11 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: htp-builder
+                  key: api-key
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -620,8 +625,8 @@ spec:
             - name: HONEYCOMB_EXPORTER_APIKEY
               valueFrom:
                 secretKeyRef:
-                  key: api-key
                   name: htp-builder
+                  key: api-key
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -489,6 +489,11 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: HONEYCOMB_EXPORTER_APIKEY
+              valueFrom:
+                secretKeyRef:
+                  name: htp-builder
+                  key: api-key
             - name: HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -611,8 +616,8 @@ spec:
             - name: HONEYCOMB_EXPORTER_APIKEY
               valueFrom:
                 secretKeyRef:
-                  key: api-key
                   name: htp-builder
+                  key: api-key
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Which problem is this PR solving?

Makes it easier for the user to configure the pipeline's ingest key, which is needed in both collector and refinery.

I went with a singular approach because at the moment the pipeline is pretty tied to a single environment. In the future when we're ready to better support more ingest keys in a pipeline (assuming we do that) we can add additional sections either at the root or nested in `ingestKey`. For now, users can add additional ingest keys to the primary collector via `primaryCollector.extraEnvs`.

- Closes https://github.com/honeycombio/pipeline-team/issues/419

## Short description of the changes

- add new section to values.yaml
- update refinery and primary collector deployments with env var. For now beekeeper doesn't need this key.

## How to verify that this has the expected result

tests and local templating
