### PR TITLE
fix(htp-builder): update executable to new name

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.67-alpha
+version: 0.0.68-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/htp-builder/templates/_helpers.tpl
+++ b/charts/htp-builder/templates/_helpers.tpl
@@ -160,7 +160,7 @@ capabilities:
   reports_remote_config: true
 
 agent:
-  executable: /otelcol-contrib
+  executable: /honeycomb-otelcol
   {{- if .Values.primaryCollector.agent.telemetry.enabled }}
   config_files: 
     - {{ .Values.primaryCollector.agent.telemetry.file }}


### PR DESCRIPTION
## Which problem is this PR solving?

In https://github.com/honeycombio/supervised-collector/pull/17 I made a breaking change to updated the executable name to be honeycomb-specific. The helm chart needs to reflect this.

## Short description of the changes

Update executable name to match supervised-collector

## How to verify that this has the expected result

sippycup
