### PR TITLE
feat: update default refinery app version to 2.9.6

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.17.0
-appVersion: 2.9.5
+version: 2.18.0
+appVersion: 2.9.6
 keywords:
   - refinery
   - honeycomb


### PR DESCRIPTION
## Which problem is this PR solving?

Update default Refinery app version to the latest 2.9.6 release

## How to verify that this has the expected result

tested locally