### PR TITLE
fix: fix render-template test script

### DIFF
--- a/tests/compare-rendered-templates.sh
+++ b/tests/compare-rendered-templates.sh
@@ -16,8 +16,6 @@ done
 
 chart_dirs=($(ls -d */))
 
-has_errors=0
-
 for chart_dir in "${chart_dirs[@]}"; do
     echo "comparing rendered and rendered_compare for $chart_dir"
 
@@ -27,8 +25,9 @@ for chart_dir in "${chart_dirs[@]}"; do
     # compare the directories and return an error if they are not the same with a print out of the line differences
     result=$(diff -u ./$base_dir ./$compare_dir)
     if [ -n "$result" ]; then
-        has_errors=1
+        echo "$result"
+        exit 1
     fi
 done
 
-exit $is_error
+exit 0

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -161,7 +161,7 @@ data:
       reports_remote_config: true
     
     agent:
-      executable: /otelcol-contrib
+      executable: /honeycomb-otelcol
       config_files: 
         - /etc/agent/config.yaml
       passthrough_logs: true
@@ -382,7 +382,7 @@ spec:
       serviceAccountName: test-htp-builder-beekeeper
       containers:
         - name: htp-builder
-          image: "honeycombio/beekeeper:v0.0.14-alpha"
+          image: "honeycombio/beekeeper:v0.0.18-alpha"
           imagePullPolicy: IfNotPresent
           args:
             - -otel-config
@@ -471,7 +471,7 @@ spec:
       serviceAccountName: test-htp-builder-primary-collector
       containers:
         - name: htp-builder
-          image: "honeycombio/supervised-collector:v0.0.6"
+          image: "honeycombio/supervised-collector:v0.0.10"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -592,7 +592,7 @@ spec:
       serviceAccountName: test-htp-builder-refinery
       containers:
         - name: htp-builder
-          image: "honeycombio/refinery:2.9.5"
+          image: "honeycombio/refinery:2.9.6"
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -161,7 +161,7 @@ data:
       reports_remote_config: true
     
     agent:
-      executable: /otelcol-contrib
+      executable: /honeycomb-otelcol
       config_files: 
         - /etc/agent/config.yaml
       passthrough_logs: true
@@ -382,7 +382,7 @@ spec:
       serviceAccountName: test-htp-builder-beekeeper
       containers:
         - name: htp-builder
-          image: "honeycombio/beekeeper:v0.0.14-alpha"
+          image: "honeycombio/beekeeper:v0.0.18-alpha"
           imagePullPolicy: IfNotPresent
           args:
             - -otel-config
@@ -471,7 +471,7 @@ spec:
       serviceAccountName: test-htp-builder-primary-collector
       containers:
         - name: htp-builder
-          image: "honeycombio/supervised-collector:v0.0.6"
+          image: "honeycombio/supervised-collector:v0.0.10"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -592,7 +592,7 @@ spec:
       serviceAccountName: test-htp-builder-refinery
       containers:
         - name: htp-builder
-          image: "honeycombio/refinery:2.9.5"
+          image: "honeycombio/refinery:2.9.6"
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -161,7 +161,7 @@ data:
       reports_remote_config: true
     
     agent:
-      executable: /otelcol-contrib
+      executable: /honeycomb-otelcol
       config_files: 
         - /etc/agent/config.yaml
       passthrough_logs: true
@@ -373,7 +373,7 @@ spec:
       serviceAccountName: test-htp-builder-beekeeper
       containers:
         - name: htp-builder
-          image: "honeycombio/beekeeper:v0.0.14-alpha"
+          image: "honeycombio/beekeeper:v0.0.18-alpha"
           imagePullPolicy: IfNotPresent
           args:
             - -otel-config
@@ -462,7 +462,7 @@ spec:
       serviceAccountName: test-htp-builder-primary-collector
       containers:
         - name: htp-builder
-          image: "honeycombio/supervised-collector:v0.0.6"
+          image: "honeycombio/supervised-collector:v0.0.10"
           imagePullPolicy: IfNotPresent
           args:
             - --config
@@ -583,7 +583,7 @@ spec:
       serviceAccountName: test-htp-builder-refinery
       containers:
         - name: htp-builder
-          image: "honeycombio/refinery:2.9.5"
+          image: "honeycombio/refinery:2.9.6"
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -154,7 +154,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu.yaml
+++ b/tests/refinery/rendered/rendered-eu.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -154,7 +154,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu1.yaml
+++ b/tests/refinery/rendered/rendered-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -154,7 +154,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-global-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -154,7 +154,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-eu1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -154,7 +154,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-us1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -144,7 +144,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-unset-region.yaml
+++ b/tests/refinery/rendered/rendered-unset-region.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -144,7 +144,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-us1.yaml
+++ b/tests/refinery/rendered/rendered-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 1
   selector:
@@ -144,7 +144,7 @@ spec:
         - name: redis
           securityContext:
             {}
-          image: "redis:7.2"
+          image: redis:7.2
           imagePullPolicy: IfNotPresent
           ports:
             - name: redis
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.5"
+    app.kubernetes.io/version: "2.9.6"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: "honeycombio/refinery:2.9.5"
+          image: honeycombio/refinery:2.9.6
           imagePullPolicy: IfNotPresent
           command:
             - refinery


### PR DESCRIPTION
## Which problem is this PR solving?

The render template test script was not properly returning an error code of 1 when the examples were out of date

## Short description of the changes

- update script to print diff
- update script to immediately return exit code 1 when test fails
- render tests that were out of date

## How to verify that this has the expected result

local testing
