### PR TITLE
feat(htp-builder): add resource attributes to refinery logs

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.0.74-alpha
+version: 0.0.75-alpha
 appVersion: 0.0.1-alpha
 keywords:
   - refinery

--- a/charts/htp-builder/templates/refinery-deployment.yaml
+++ b/charts/htp-builder/templates/refinery-deployment.yaml
@@ -53,6 +53,8 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
+              value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               {{- if .Values.telemetry.ingestKey.value }}
               value: {{ .Values.telemetry.ingestKey.value }}

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -623,6 +623,8 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
+              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -623,6 +623,8 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
+              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -614,6 +614,8 @@ spec:
                   fieldPath: status.podIP
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
+              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the pipeline.id (and other resource attributes) to Refinery logs. 

## Short description of the changes

Adds the `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS` to the refinery deployment

## How to verify that this has the expected result

tests
