### PR TITLE
maint(refinery): bump default refinery version to v2.9.7

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 2.18.1
-appVersion: 2.9.6
+version: 2.18.2
+appVersion: 2.9.7
 keywords:
   - refinery
   - honeycomb

--- a/tests/refinery/rendered/rendered-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu.yaml
+++ b/tests/refinery/rendered/rendered-eu.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu1.yaml
+++ b/tests/refinery/rendered/rendered-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-global-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-eu1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -65,7 +65,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -83,7 +83,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -104,7 +104,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -134,7 +134,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -170,7 +170,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -196,7 +196,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-us1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-unset-region.yaml
+++ b/tests/refinery/rendered/rendered-unset-region.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-us1.yaml
+++ b/tests/refinery/rendered/rendered-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "2.9.6"
+    app.kubernetes.io/version: "2.9.7"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: honeycombio/refinery:2.9.6
+          image: honeycombio/refinery:2.9.7
           imagePullPolicy: IfNotPresent
           command:
             - refinery


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes https://github.com/honeycombio/helm-charts/issues/524

## Short description of the changes
bump appVersion to v2.9.7

## How to verify that this has the expected result
tests