### PR TITLE
fix(htp-builder): fix broken REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES env var

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 keywords:
   - refinery

--- a/charts/htp-builder/templates/refinery-deployment.yaml
+++ b/charts/htp-builder/templates/refinery-deployment.yaml
@@ -49,8 +49,8 @@ spec:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
-              value: pipeline.id={{ .Values.pipeline.id }},k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+              value: pipeline.id:{{ .Values.pipeline.id }},k8s.namespace.name:$(K8S_NAMESPACE_NAME),k8s.node.name:$(K8S_NODE_NAME),k8s.pod.name:$(K8S_POD_NAME),k8s.pod.uid:$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               {{- if .Values.telemetry.ingestKey.value }}
               value: {{ .Values.telemetry.ingestKey.value }}

--- a/tests/htp-builder/rendered/rendered-customEndpoint.yaml
+++ b/tests/htp-builder/rendered/rendered-customEndpoint.yaml
@@ -619,8 +619,8 @@ spec:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
-              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+              value: pipeline.id:test-installation-id,k8s.namespace.name:$(K8S_NAMESPACE_NAME),k8s.node.name:$(K8S_NODE_NAME),k8s.pod.name:$(K8S_POD_NAME),k8s.pod.uid:$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-eu1.yaml
+++ b/tests/htp-builder/rendered/rendered-eu1.yaml
@@ -619,8 +619,8 @@ spec:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
-              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+              value: pipeline.id:test-installation-id,k8s.namespace.name:$(K8S_NAMESPACE_NAME),k8s.node.name:$(K8S_NODE_NAME),k8s.pod.name:$(K8S_POD_NAME),k8s.pod.uid:$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/tests/htp-builder/rendered/rendered-unset-region.yaml
+++ b/tests/htp-builder/rendered/rendered-unset-region.yaml
@@ -610,8 +610,8 @@ spec:
                   fieldPath: metadata.uid
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
-            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_FIELDS
-              value: pipeline.id=test-installation-id,k8s.namespace.name=$(K8S_NAMESPACE_NAME),k8s.node.name=$(K8S_NODE_NAME),k8s.pod.name=$(K8S_POD_NAME),k8s.pod.uid=$(K8S_POD_UID)
+            - name: REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES
+              value: pipeline.id:test-installation-id,k8s.namespace.name:$(K8S_NAMESPACE_NAME),k8s.node.name:$(K8S_NODE_NAME),k8s.pod.name:$(K8S_POD_NAME),k8s.pod.uid:$(K8S_POD_UID)
             - name: REFINERY_HONEYCOMB_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Which problem is this PR solving?

Fixes a bug where the `REFINERY_HONEYCOMB_LOGGER_ADDITIONAL_ATTRIBUTES` env var was not properly configured

## Short description of the changes

- update env var name
- update env var value to use `:`, which is what refinery requires.

## How to verify that this has the expected result

installed in test cluster.
