### PR TITLE
feat(htp-builder): use unique key for pipeline telemetry

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 0.1.0
 keywords:
   - refinery

--- a/charts/htp-builder/README.md
+++ b/charts/htp-builder/README.md
@@ -14,9 +14,11 @@ Create a Kubernetes secret to store your API Key
 
 ```shell
 export HONEYCOMB_API_KEY=mykey
+export HONEYCOMB_PIPELINE_TELEMETRY_KEY=mypipelinetelemetrykey
 export HONEYCOMB_MGMT_API_SECRET=mymanagementsecret
 kubectl create secret generic htp-builder \
     --from-literal=api-key=$HONEYCOMB_API_KEY \
+    --from-literal=pipeline-telemetry-key=$HONEYCOMB_PIPELINE_TELEMETRY_KEY \
     --from-literal=management-api-secret=$HONEYCOMB_MGMT_API_SECRET
 ```
 

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -41,7 +41,7 @@ telemetry:
       # The name of the kubernetes secret providing the ingest key
       name: "htp-builder"
       # The name of the field in the secret which stores the ingest key
-      key: "api-key"
+      key: "pipeline-telemetry-key"
 
 # This setting configures regional configuration (like endpoints) across all artifacts.
 # Artifact-specific configuration is still supported and will take precedence.


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the chart's default install to reference the instruction's key name for the pipeline telemetry key.

- Closes https://github.com/honeycombio/pipeline-team/issues/583

## Short description of the changes

- update telemetry key name to match install instructions
- update README instructions
- bump chart version

## How to verify that this has the expected result

local testing
