### PR TITLE
feat(htp-builder): add global to values schema

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.1.0
 keywords:
   - refinery

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -7,6 +7,9 @@
     "enabled": {
       "type": "boolean"
     },
+    "global": {
+      "type": "object"
+    },
     "pipeline": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Which problem is this PR solving?

Adds `global` to the json schema so that the field is usable when subcharting.