### PR TITLE
maint(refinery): remove BufferSizes from config schema

### DIFF
--- a/charts/refinery/values.schema.json
+++ b/charts/refinery/values.schema.json
@@ -75,9 +75,6 @@
         "Collection": {
           "type": "object"
         },
-        "BufferSizes": {
-          "type": "object"
-        },
         "Specialized": {
           "type": "object"
         },


### PR DESCRIPTION
## Which problem is this PR solving?

In the upcoming Refinery 3 release, Refinery has removed the need to configure buffer sizes.

## Short description of the changes

remove `BufferSizes` from schema file
