### PR TITLE
maint(htp-bindplane): update htp and htp-bindplane charts to 1.31.0

### DIFF
--- a/charts/htp-bindplane/Chart.lock
+++ b/charts/htp-bindplane/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.29.3
-digest: sha256:9fcba6be7b7db32227c6e9fd4cf694eed33df5499c3c94b62aa4b6cab0536cae
-generated: "2025-10-08T11:35:30.037631-04:00"
+  version: 1.31.0
+digest: sha256:f10c45d2ec474e1367ce89a45c882c8c7b94ecf3e6a54ec52ed1ed62e05bdbb5
+generated: "2025-10-08T08:39:57.194413-07:00"

--- a/charts/htp-bindplane/Chart.yaml
+++ b/charts/htp-bindplane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp-bindplane
 description: Honeycomb Telemetry Pipeline - Bindplane
 type: application
-version: 0.2.2
-appVersion: 1.91.1
+version: 0.2.3
+appVersion: 1.92.0
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm
@@ -13,6 +13,6 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
   - name: bindplane
-    version: "1.29.3"
+    version: "1.31.0"
     repository: "https://observiq.github.io/bindplane-op-helm"
     alias: htp

--- a/charts/htp/Chart.lock
+++ b/charts/htp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.29.3
-digest: sha256:9fcba6be7b7db32227c6e9fd4cf694eed33df5499c3c94b62aa4b6cab0536cae
-generated: "2025-10-08T11:35:22.705853-04:00"
+  version: 1.31.0
+digest: sha256:f10c45d2ec474e1367ce89a45c882c8c7b94ecf3e6a54ec52ed1ed62e05bdbb5
+generated: "2025-10-08T08:39:51.512812-07:00"

--- a/charts/htp/Chart.yaml
+++ b/charts/htp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp
 description: Honeycomb Telemetry Pipeline
 type: application
-version: 0.2.2
-appVersion: 1.91.1
+version: 0.2.3
+appVersion: 1.92.0
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm
@@ -13,6 +13,6 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
   - name: bindplane
-    version: "1.29.3"
+    version: "1.31.0"
     repository: "https://observiq.github.io/bindplane-op-helm"
     alias: htp


### PR DESCRIPTION
This is a retroactive release to support 1.31.0
