### PR TITLE
maint(htp-bindplane): update htp and htp-bindplane charts to 1.31.1 

### DIFF
--- a/charts/htp-bindplane/Chart.lock
+++ b/charts/htp-bindplane/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.29.2
-digest: sha256:e66d31950541170db5fdaa7e3cb6532c7d44c9997a11a5c519fcd491580e710a
-generated: "2025-10-08T08:29:15.664774-07:00"
+  version: 1.31.1
+digest: sha256:666bd79df0517f04adffd3ef3c6136e611d71c061de008d3cebd945e2f0abbf3
+generated: "2025-10-08T11:37:40.760425-04:00"

--- a/charts/htp-bindplane/Chart.yaml
+++ b/charts/htp-bindplane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp-bindplane
 description: Honeycomb Telemetry Pipeline - Bindplane
 type: application
-version: 0.2.1
-appVersion: 1.90.2
+version: 0.2.4
+appVersion: 1.94.0
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm
@@ -13,6 +13,6 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
   - name: bindplane
-    version: "1.29.2"
+    version: "1.31.1"
     repository: "https://observiq.github.io/bindplane-op-helm"
     alias: htp

--- a/charts/htp/Chart.lock
+++ b/charts/htp/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: bindplane
   repository: https://observiq.github.io/bindplane-op-helm
-  version: 1.29.2
-digest: sha256:e66d31950541170db5fdaa7e3cb6532c7d44c9997a11a5c519fcd491580e710a
-generated: "2025-10-08T08:29:06.297857-07:00"
+  version: 1.31.1
+digest: sha256:666bd79df0517f04adffd3ef3c6136e611d71c061de008d3cebd945e2f0abbf3
+generated: "2025-10-08T11:38:11.495139-04:00"

--- a/charts/htp/Chart.yaml
+++ b/charts/htp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp
 description: Honeycomb Telemetry Pipeline
 type: application
-version: 0.2.1
-appVersion: 1.90.2
+version: 0.2.4
+appVersion: 1.94.0
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm
@@ -13,6 +13,6 @@ maintainers:
     email: pipeline-team@honeycomb.io
 dependencies:
   - name: bindplane
-    version: "1.29.2"
+    version: "1.31.1"
     repository: "https://observiq.github.io/bindplane-op-helm"
     alias: htp


### PR DESCRIPTION
This is a retroactive release to support 1.31.1