### PR TITLE
maint(htp-bindplane): update htp and htp-bindplane appVersion to 1.94.3

### DIFF
--- a/charts/htp-bindplane/Chart.yaml
+++ b/charts/htp-bindplane/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp-bindplane
 description: Honeycomb Telemetry Pipeline - Bindplane
 type: application
-version: 0.2.4
-appVersion: 1.94.0
+version: 0.2.5
+appVersion: 1.94.3
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm

--- a/charts/htp/Chart.yaml
+++ b/charts/htp/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: htp
 description: Honeycomb Telemetry Pipeline
 type: application
-version: 0.2.4
-appVersion: 1.94.0
+version: 0.2.5
+appVersion: 1.94.3
 home: https://honeycomb.io
 sources:
   - https://github.com/observIQ/bindplane-op-helm


### PR DESCRIPTION
The last published helm chart already supports the upstream chart `1.31.1`, but this publishes using the newer `appVersion` `1.94.3`. This is the same published chart as `0.2.0`, being republished to ensure the latest available versions are published most recently after the retroactive releases prior to this.

Because the upstream helm chart version didn't change there are no dependency updates needed.