### PR TITLE
chore: add dependabot for htp and htp-bindplane

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       - "./charts/htp-bindplane"
     schedule:
       interval: "daily"
+    labels:
+      - "type: dependencies"
+    commit-message:
+      prefix: "maint"
+      include: "scope"


### PR DESCRIPTION
## Which problem is this PR solving?

- get PRs for updating dependency charts in htp and htp-bindplane

## Short description of the changes

- add dependabot for helm, for htp and htp-bindplane charts

## How to verify that this has the expected result

- the next release from bindplane helm chart should trigger a PR to open here