### PR TITLE
feat(htp-builder): support ingress for primaryCollector [PIPE-208]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@
 .vscode/
 *.code-workspace
 
+### Claude Code ###
+.claude/
+
 tests/*/rendered-compare

--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.1.4
+version: 0.2.0
 appVersion: 0.1.1
 keywords:
   - refinery
@@ -16,6 +16,7 @@ keywords:
 home: https://honeycomb.io
 sources:
   - https://github.com/honeycombio/refinery
+  - https://github.com/honeycombio/supervised-collector
   - https://github.com/open-telemetry/opentelemetry-collector-releases
 icon: https://www.honeycomb.io/wp-content/themes/honeycomb/assets/img/logo.svg
 maintainers:

--- a/charts/htp-builder/templates/primary-collector-ingress.yaml
+++ b/charts/htp-builder/templates/primary-collector-ingress.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.primaryCollector.ingress.enabled -}}
+{{- $ingresses := prepend .Values.primaryCollector.ingress.additionalIngresses .Values.primaryCollector.ingress -}}
+{{- range $ingresses }}
+apiVersion: "networking.k8s.io/v1"
+kind: Ingress
+metadata:
+  {{- if .name }}
+  name: {{ printf "%s-primary-collector-%s" (include "htp-builder.fullname" $) .name }}
+  {{- else }}
+  name: {{ include "htp-builder.fullname" $ }}-primary-collector
+  {{- end }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "htp-builder.primaryCollector.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: collector
+  {{- if .annotations }}
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .ingressClassName }}
+  ingressClassName: {{ .ingressClassName }}
+  {{- end -}}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
+      {{- with .secretName }}
+      secretName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "htp-builder.fullname" $ }}-primary-collector
+                port:
+                  number: {{ .port }}
+          {{- end }}
+    {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/charts/htp-builder/templates/primary-collector-service.yaml
+++ b/charts/htp-builder/templates/primary-collector-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.primaryCollector.service.enabled }}
+{{- if or .Values.primaryCollector.service.enabled .Values.primaryCollector.ingress.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/htp-builder/values.schema.json
+++ b/charts/htp-builder/values.schema.json
@@ -482,6 +482,135 @@
               }
             }
           }
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "annotations": {
+              "type": "object"
+            },
+            "ingressClassName": {
+              "type": "string"
+            },
+            "hosts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "host": {
+                    "type": "string"
+                  },
+                  "paths": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "pathType": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "secretName": {
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "additionalIngresses": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "annotations": {
+                    "type": "object"
+                  },
+                  "ingressClassName": {
+                    "type": "string"
+                  },
+                  "hosts": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "paths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                              "path": {
+                                "type": "string"
+                              },
+                              "pathType": {
+                                "type": "string"
+                              },
+                              "port": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "tls": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "properties": {
+                        "secretName": {
+                          "type": "string"
+                        },
+                        "hosts": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/charts/htp-builder/values.yaml
+++ b/charts/htp-builder/values.yaml
@@ -337,3 +337,37 @@ primaryCollector:
       # Override Primary Collector opampsupervisor's default OTel SDK Configuration.
       # Config set here will take precedence over config produced by 'telemetry' and 'region'.
       config: {}
+
+  # Ingress configuration for the Primary Collector
+  ingress:
+    enabled: false
+    # annotations: {}
+    # ingressClassName: nginx
+    # hosts:
+    #   - host: primary-collector.example.com
+    #     paths:
+    #       - path: /
+    #         pathType: Prefix
+    #         port: 4318
+    # tls:
+    #   - secretName: primary-collector-tls
+    #     hosts:
+    #       - primary-collector.example.com
+
+    # Additional ingresses - only created if ingress.enabled is true
+    # Useful for when differently annotated ingress services are required
+    # Each additional ingress needs key "name" set to something unique
+    additionalIngresses: []
+    # - name: grpc
+    #   ingressClassName: nginx
+    #   annotations: {}
+    #   hosts:
+    #     - host: primary-collector-grpc.example.com
+    #       paths:
+    #         - path: /
+    #           pathType: Prefix
+    #           port: 4317
+    #   tls:
+    #     - secretName: primary-collector-grpc-tls
+    #       hosts:
+    #         - primary-collector-grpc.example.com


### PR DESCRIPTION
## Which problem is this PR solving?

Adds Ingress support to `htp-builder` primaryCollector following pattern from the open-telemetry/opentelemetry-collector helm chart.

Closes PIPE-208

## Short description of the changes

- Add new ingress template to render an Ingress object
- update values.yaml to allow configuring an ingress for the primary collector
- update json schema

## How to verify that this has the expected result

helm template locally.
