### PR TITLE
maint: remove htp from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@ version: 2
 updates:
   - package-ecosystem: "helm"
     directories:
-      - "./charts/htp"
       - "./charts/htp-bindplane"
     schedule:
       interval: "daily"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.code-workspace
 
 tests/*/rendered-compare
+
+.claude/


### PR DESCRIPTION
## Which problem is this PR solving?

since `htp` chart is sunset we dont need to update it anymore. Remove it from dependabot