### PR TITLE
feat(htp-builder): ensure future support for Refinery 3.x

### DIFF
--- a/charts/htp-builder/Chart.yaml
+++ b/charts/htp-builder/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: htp-builder
 description: Chart to deploy Honeycomb Telemetry Pipeline Builder
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: 0.1.1
 keywords:
   - refinery

--- a/charts/htp-builder/templates/_helpers.tpl
+++ b/charts/htp-builder/templates/_helpers.tpl
@@ -375,8 +375,10 @@ Network:
   HoneycombAPI: https://api.eu1.honeycomb.io
 HoneycombLogger:
   APIHost: {{ default "https://api.eu1.honeycomb.io" .Values.telemetry.endpoint }}
+{{- if hasPrefix "2" .Values.refinery.image.tag }}
 LegacyMetrics:
   APIHost: {{ default "https://api.eu1.honeycomb.io" .Values.telemetry.endpoint }}
+{{- end }}
 OTelMetrics:
   APIHost: {{ default "https://api.eu1.honeycomb.io" .Values.telemetry.endpoint }}
 OTelTracing:
@@ -388,8 +390,10 @@ Network:
   HoneycombAPI: {{ .customEndpoint }}
 HoneycombLogger:
   APIHost: {{ default .customEndpoint .Values.telemetry.endpoint }}
+{{- if hasPrefix "2" .Values.refinery.image.tag }}
 LegacyMetrics:
   APIHost: {{ default .customEndpoint .Values.telemetry.endpoint }}
+{{- end }}
 OTelMetrics:
   APIHost: {{ default .customEndpoint .Values.telemetry.endpoint }}
 OTelTracing:


### PR DESCRIPTION
## Which problem is this PR solving?

If we try to use Refinery 3 with the `eu1` or `custom` regions, the chart was setting `LegacyMetrics` which was removed in 3.0.  This PR updates that configuration to be specific to v2.x of refinery.

## Short description of the changes

- add rendering logic to the region template to only render LegacyMetrics configuration if the refinery image tag starts with 2.

## How to verify that this has the expected result

local rendering and sippycup
