### PR TITLE
fix(refinery): Adjust deployment marker hook naming and delete policy

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 3.2.0
+version: 3.2.1
 appVersion: 3.2.0
 keywords:
   - refinery

--- a/charts/refinery/templates/deployment-marker-job.yaml
+++ b/charts/refinery/templates/deployment-marker-job.yaml
@@ -2,14 +2,14 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "refinery.fullname" . }}-deploy-marker-{{ randAlphaNum 5 | lower }}
+  name: {{ include "refinery.fullname" . }}-deploy-marker
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "refinery.labels" . | nindent 4 }}
 
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
   template:
     spec:


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
The Refinery chart's current implementation of deploy markers can lead to the accumulation of orphaned jobs when Helm encounters interruptions or failures. Additionally, applying the chart through ArgoCD translates the defined hooks into Argo semantics (sync hooks), which are even more prone to leaking jobs when errors arise.

#400 introduced the deploy markers feature, specifying a deletion policy of `hook-succeeded` in the job definition. This overrides the default `before-hook-creation`, which clears any previous jobs before running the next. Since `hook-succeeded` functions as it says on the tin, any failed hooks would leave an orphaned job that could block future upgrades.

#408 addressed this issue by adding a randomized 5 character suffix to each job, preventing existing resources with the same name from impeding deployments. This change was targeted specifically at concurrent operations, but ensured jobs wouldn't block for any number of reasons.

While effective, this functioned as a bit of a sidestep around the underlying issue.

## Short description of the changes
By making two small edits to `charts/refinery/templates/deployment-marker-job.yaml`, both the blocking and job orphaning issues can be remedied.

- Adding `before-hook-creation` to the deletion policy clears any existing jobs with the same name before launching another.
- With the above, the randomized suffix is no longer needed, as unique job names would end up hindering the deletion policy's work. Failed jobs are then cleaned up appropriately, preventing orphans from building up.

This implementation should have no or positive impact on pure Helm deployments while improving life for anyone using Argo.

In the situation #408 aimed to address, two concurrent Helm upgrades of the same release would result in both jobs creating a marker. After this change, the later job would kill the in-flight job (if it was still running) and emit only the second marker. Despite being a minor behavioral change, the frequency of those exact circumstances arising feels exceptionally low. Helm serializes upgrade operations, rejecting additional changes while the current process runs, and `before-hook-creation` is the default setting.

## How to verify that this has the expected result
Ensure that deploying the chart creates a single job with a consistent name that is replaced by subsequent runs.