### PR TITLE
maint: bump Refinery version to v3.2.1

### DIFF
--- a/charts/refinery/Chart.yaml
+++ b/charts/refinery/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: refinery
 description: Chart to deploy Honeycomb Refinery
 type: application
-version: 3.2.1
-appVersion: 3.2.0
+version: 3.2.2
+appVersion: 3.2.1
 keywords:
   - refinery
   - honeycomb

--- a/tests/refinery/rendered/rendered-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -132,7 +132,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -168,7 +168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -194,7 +194,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu.yaml
+++ b/tests/refinery/rendered/rendered-eu.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -132,7 +132,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -168,7 +168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -194,7 +194,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-eu1.yaml
+++ b/tests/refinery/rendered/rendered-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -132,7 +132,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -168,7 +168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -194,7 +194,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-customEndpoint.yaml
+++ b/tests/refinery/rendered/rendered-global-customEndpoint.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -132,7 +132,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -168,7 +168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -194,7 +194,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-eu1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-eu1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -63,7 +63,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -81,7 +81,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -102,7 +102,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -132,7 +132,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -168,7 +168,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -194,7 +194,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-global-region-us1.yaml
+++ b/tests/refinery/rendered/rendered-global-region-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-unset-region.yaml
+++ b/tests/refinery/rendered/rendered-unset-region.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery

--- a/tests/refinery/rendered/rendered-us1.yaml
+++ b/tests/refinery/rendered/rendered-us1.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 ---
 # Source: refinery/templates/configmap-config.yaml
 apiVersion: v1
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   config.yaml: |
     Collection:
@@ -55,7 +55,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 data:
   rules.yaml: |
     RulesVersion: 2
@@ -73,7 +73,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -94,7 +94,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   type: ClusterIP
   ports:
@@ -124,7 +124,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery-redis
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 1
   selector:
@@ -160,7 +160,7 @@ metadata:
   labels:
     app.kubernetes.io/name: refinery
     app.kubernetes.io/instance: test
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "3.2.1"
 spec:
   replicas: 3
   selector:
@@ -186,7 +186,7 @@ spec:
         - name: refinery
           securityContext:
             {}
-          image: ghcr.io/honeycombio/refinery/refinery:3.2.0
+          image: ghcr.io/honeycombio/refinery/refinery:3.2.1
           imagePullPolicy: IfNotPresent
           command:
             - refinery


### PR DESCRIPTION
## Which problem is this PR solving?

bump refinery version to v3.2.1 and publish a new chart version v3.2.2